### PR TITLE
Use str instead of a specialized class for native ids (although allow…

### DIFF
--- a/src/psi/j/__init__.py
+++ b/src/psi/j/__init__.py
@@ -16,14 +16,13 @@ from .job_spec import JobSpec
 from .job_state import JobState
 from .job_status import JobStatus
 from .launchers.launcher import Launcher
-from .native_id import NativeId
 from .resource_spec import ResourceSpec, ResourceSpecV1
 
 
 __all__ = [
     'JobExecutor', 'JobExecutorConfig', 'Job', 'JobStatusCallback', 'JobSpec', 'JobAttributes',
-    'JobStatus', 'JobState', 'ResourceSpec', 'ResourceSpecV1', 'NativeId', 'Launcher',
-    'SubmitException', 'InvalidJobException', 'UnreachableStateException'
+    'JobStatus', 'JobState', 'ResourceSpec', 'ResourceSpecV1', 'Launcher', 'SubmitException',
+    'InvalidJobException', 'UnreachableStateException'
 ]
 
 logger = logging.getLogger(__name__)

--- a/src/psi/j/job.py
+++ b/src/psi/j/job.py
@@ -10,7 +10,6 @@ from psi.j.exceptions import SubmitException, UnreachableStateException
 from psi.j.job_spec import JobSpec
 from psi.j.job_state import JobState
 from psi.j.job_status import JobStatus
-from psi.j.native_id import NativeId
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +46,9 @@ class Job:
         self._status = JobStatus(JobState.NEW)
         # need indirect ref to avoid a circular reference
         self._executor = None  # type: Optional['psi.j.JobExecutor']
-        self._native_id = None  # type: Optional[NativeId]
+        # allow the native ID to be anything and do the string conversion in the getter; there's
+        # no point in storing integers as strings.
+        self._native_id = None  # type: Optional[object]
         self.status_callback = None  # type: Optional[JobStatusCallback]
         """Setting this property registers a :class:`~psi.j.JobStatusCallback` with this executor.
         The callback will be invoked whenever a status change occurs for any of the jobs submitted
@@ -70,14 +71,17 @@ class Job:
         return self._id
 
     @property
-    def native_id(self) -> Optional[NativeId]:
+    def native_id(self) -> Optional[str]:
         """
         Returns the native ID of this job.
 
         The native ID may not be available until after the job is submitted to a
         :class:`~psi.j.JobExecutor`.
         """
-        return self._native_id
+        if self._native_id is None:
+            return None
+        else:
+            return str(self._native_id)
 
     @property
     def status(self) -> JobStatus:

--- a/src/psi/j/job_executor.py
+++ b/src/psi/j/job_executor.py
@@ -9,7 +9,6 @@ import psi.j
 from psi.j.job import Job, JobStatusCallback
 from psi.j.job_executor_config import JobExecutorConfig
 from psi.j.launchers.launcher import Launcher
-from psi.j.native_id import NativeId
 
 
 class JobExecutor(ABC):
@@ -91,12 +90,12 @@ class JobExecutor(ABC):
         pass
 
     @abstractmethod
-    def attach(self, job: Job, native_id: NativeId) -> None:
+    def attach(self, job: Job, native_id: str) -> None:
         """
         Attaches a job to a native job.
 
         :param job: A job to attach. The job must be in the :attr:`~psi.j.JobState.NEW` state.
-        :param native_id: The native ID to attach to.
+        :param native_id: The native ID to attach to as returned by :attr:`~psi.j.Job.native_id`.
         """
         pass
 

--- a/src/psi/j/native_id.py
+++ b/src/psi/j/native_id.py
@@ -1,9 +1,0 @@
-class NativeId:
-    """
-    Represents a native job identifier.
-
-    This is a base class for all concrete implementations of native IDs, which are specific to each
-    executor and otherwise opaque.
-    """
-
-    pass


### PR DESCRIPTION
… Job to maintain the native id in another representation)

I'm still a bit fuzzy whether this is the right solution or whether we should add to/from str methods to NativeID.