### PR TITLE
When job output is redirected, a file is opened for that purpose. A m…

### DIFF
--- a/src/psi/j/executors/local.py
+++ b/src/psi/j/executors/local.py
@@ -153,6 +153,7 @@ class _ProcessReaper(threading.Thread):
             exit_code = entry.poll()
             if exit_code is not None:
                 entry.exit_code = exit_code
+                entry.close()
                 entry.done_time = time.time()
                 done.append(entry)
         for entry in done:


### PR DESCRIPTION
…ethod existed to close those files, but was not properly called. This commit fixes that.