### PR TITLE
3.6 compatibility

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,8 +25,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Lint with flake8

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,9 +29,6 @@ jobs:
         python -m pip install flake8 pytest
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-    - name: Build scripts
-      run: |
-        make launcher-scripts
     - name: Lint with flake8
       run: |
         make checks

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+    - name: Build scripts
+      run: |
+        make launcher-scripts
+    - name: Lint with flake8
+      run: |
+        make checks
+    - name: Test with pytest
+      run: |
+        make tests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ CWD = $(shell pwd)
 PYTHON = $(shell if python --version 2>&1 | egrep -q 'Python 3\..*' ; then echo "python"; else echo "python3"; fi)
 
 .PHONY: tests
-
 tests:
 	PYTHONPATH=$(CWD)/src ${PYTHON} -m pytest
 
@@ -21,7 +20,6 @@ check: typecheck stylecheck
 
 
 .PHONY: genautodocs
-
 genautodocs: 
 	rm -rf docs/.generated
 	mkdir docs/.generated
@@ -29,11 +27,9 @@ genautodocs:
 	
 
 .PHONY: docs
-
 docs: genautodocs docs-noauto
 
 
 .PHONY: docs-noauto
-
 docs-noauto:
 	sphinx-build -W -b html docs docs/.build/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ sphinx-tabs
 # sphinx-autodoc-typehints
 
 mypy >=0.790
+pytest
+flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ sphinx_rtd_theme
 sphinx-tabs
 # sphinx-autodoc-typehints
 
+mypy >=0.790

--- a/src/psi/j/executors/local.py
+++ b/src/psi/j/executors/local.py
@@ -1,4 +1,4 @@
-"""This module contains the local :class:`psi.j.job_executor.JobExecutor`."""
+"""This module contains the local :class:`~psi.j.JobExecutor`."""
 from __future__ import annotations
 
 import logging

--- a/src/psi/j/executors/local.py
+++ b/src/psi/j/executors/local.py
@@ -1,6 +1,4 @@
 """This module contains the local :class:`~psi.j.JobExecutor`."""
-from __future__ import annotations
-
 import logging
 import os
 import subprocess
@@ -24,7 +22,7 @@ _REAPER_SLEEP_TIME = 0.2
 
 
 class _ProcessEntry(ABC):
-    def __init__(self, job: Job, executor: LocalJobExecutor):
+    def __init__(self, job: Job, executor: 'LocalJobExecutor'):
         self.job = job
         self.executor = executor
         self.exit_code = None  # type: Optional[int]
@@ -45,7 +43,7 @@ class _ProcessEntry(ABC):
 
 
 class _ChildProcessEntry(_ProcessEntry):
-    def __init__(self, job: Job, executor: LocalJobExecutor) -> None:
+    def __init__(self, job: Job, executor: 'LocalJobExecutor') -> None:
         super().__init__(job, executor)
         self.streams = []  # type: List[IO[Any]]
         self.process = None  # type: Optional[subprocess.Popen[bytes]]
@@ -75,7 +73,7 @@ class _ChildProcessEntry(_ProcessEntry):
 
 
 class _AttachedProcessEntry(_ProcessEntry):
-    def __init__(self, job: Job, process: psutil.Process, executor: LocalJobExecutor):
+    def __init__(self, job: Job, process: psutil.Process, executor: 'LocalJobExecutor'):
         super().__init__(job, executor)
         self.process = process
 
@@ -116,7 +114,7 @@ class _ProcessReaper(threading.Thread):
     _lock = threading.RLock()
 
     @classmethod
-    def get_instance(cls: Type[_ProcessReaper]) -> _ProcessReaper:
+    def get_instance(cls: Type['_ProcessReaper']) -> '_ProcessReaper':
         with cls._lock:
             if cls._instance is None:
                 cls._instance = _ProcessReaper()

--- a/tests/test_local_jobs.py
+++ b/tests/test_local_jobs.py
@@ -71,4 +71,3 @@ def test_missing_executable() -> None:
         assert status.exit_code != 0
     except SubmitException:
         pass
-


### PR DESCRIPTION
The problem was caused by "from __future__ import annotations", which is there to support forward type definitions (e.g., `class A: def fn(a: A):...` instead of having to quote A - `class A: def fn(a: 'A'):...`)