### PR TITLE
Fixed a nested path executor loading issue

### DIFF
--- a/src/psi/j/job_executor.py
+++ b/src/psi/j/job_executor.py
@@ -220,6 +220,9 @@ class JobExecutor(ABC):
         if index != len(existing) and existing[index].version == version:
             p1 = inspect.getfile(existing[index].ecls)
             p2 = inspect.getfile(ecls)
+            if p1 == p2:
+                # can happen if PYTHONPATH has, e.g., a/, a/b/, so ignore silently
+                return
             raise ValueError(('An executor by the name "{}" with version {} is already '
                               'registered. Existing path: {}; current path: {}').format(name,
                                                                                         version,


### PR DESCRIPTION
Fixed an error in which nested paths in PYTHONPATH can lead to the same executor being loaded twice, which can lead to an executor loading error