### PR TITLE
linting rp connector

### DIFF
--- a/.mypy
+++ b/.mypy
@@ -5,3 +5,6 @@ ignore_missing_imports = True
 
 [mypy-psutil.*]
 ignore_missing_imports = True
+
+[mypy-radical.*]
+ignore_missing_imports = True

--- a/src/psi/j/job_executor.py
+++ b/src/psi/j/job_executor.py
@@ -117,6 +117,13 @@ class JobExecutor(ABC):
         pass
 
     @abstractmethod
+    def list(self) -> List[str]:
+        """
+        List native IDs of all jobs known to the backend.
+        """
+        pass
+
+    @abstractmethod
     def attach(self, job: Job, native_id: str) -> None:
         """
         Attaches a job to a native job.


### PR DESCRIPTION
This PR  attempts to fix the mypy linting errors in the RP connector.  It also adds the missing `psi.j.job_executor.list()` stub which mypy complained about.

The linter still fails because it cannot import the radical modules - they are not installed as dependency.  Even if installed, mypy wil still complain because the radical modules do not use type hints.  How should we handle this?