### PR TITLE
Code style etc

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+        pip install -r requirements-connector-radical.txt
     - name: Lint with flake8
       run: |
         make checks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contribution Guide
+
+This project welcomes all contributors. This short guide (based loosely on [
+Collective Code Construction Contract](http://zeromq-rfc.wikidot.com/spec:22)
+and [matplotlib's development
+workflow](https://matplotlib.org/stable/devel/gitwash/development_workflow.html#development-workflow))
+details how to contribute in a standardized and efficient manner.
+
+## Git Workflow Summary
+
+- Ensure that you've opened an Issue on Github and consensus around the
+  solution has be reached.
+  - Minor changes (e.g., grammatical fixes) do not require an Issue first.
+- [Create your own
+  fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo).
+- When you are starting a new set of changes, [fetch any changes from the
+  upstream
+  repo](https://matplotlib.org/stable/devel/gitwash/development_workflow.html#update-the-mirror-of-trunk),
+  and [start a new feature branch on your fork from
+  that](https://matplotlib.org/stable/devel/gitwash/development_workflow.html#make-a-new-feature-branch).
+- Make a new branch for each separable set of changes — ["one task, one
+  branch"](https://mail.python.org/pipermail/ipython-dev/2010-October/005632.html)
+- [Each commit should make one change](https://dev.to/ruanbrandao/how-to-make-good-git-commits-256k).
+  to aide reviewing and (in the worst case) simplify reverting it in the future.
+  - A patch commit message should consist of a single short (less than 50
+    character) line summarizing the change, optionally followed by a blank line
+    and then a more thorough description.
+  - Where applicable, a PR or commit message body should reference an Issue by
+    number (e.g. `Fixes #33`).
+- If you can possibly avoid it, avoid merging upstream branches or any other
+  branches into your feature branch while you are working.
+  - If you do find yourself merging from upstream, consider [Rebasing on
+    upstream](https://matplotlib.org/stable/devel/gitwash/development_workflow.html#rebase-on-trunk).
+- Submit a Pull Request from your feature branch against upstream.
+  - Use the Draft PR feature on Github or title your PR with `WIP` if your PR is
+    not ready for a complete review immediately upon submission.
+- Ask on the [Exaworks slack](https://exaworks.slack.com) if you get stuck.
+
+
+## Pull Request (PR) Merging Process
+
+- PR reviews should be timely. Both reviewer and PR issuer should make a good
+  attempt at resolving the conversation as quickly as possible.
+- PR reviews exist to check obvious things aren't missed, not to achieve
+  perfection.
+- A PR is eligible for merging if it has at least one approval from a
+  project maintainer, no outstanding requested changes or discussions, and passes
+  CI tests (if configured for the repository).
+- Discussions created via an inline comment on GitHub should only be "resolved"
+  by whomever opened the discussion.
+- The person to mark the last open discussion "resolved" should also merge the
+  PR ("close the door when you leave"), unless a merge bot is configured for the
+  repository, in which case the PR should be left for the bot to merge.
+- Maintainers should not merge their own patches except in exceptional cases.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,3 +52,10 @@ details how to contribute in a standardized and efficient manner.
   PR ("close the door when you leave"), unless a merge bot is configured for the
   repository, in which case the PR should be left for the bot to merge.
 - Maintainers should not merge their own patches except in exceptional cases.
+
+## Code Style
+
+All code should conform to [PEP8](https://www.python.org/dev/peps/pep-0008/).
+This compliance can be checked with `make stylecheck` or `make checks` and
+be automatically achieved by running `make style`, which runs `autopep8`
+under-the-hood. PEP8 compliance is also verified as part of the CI by `flake8`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,12 @@ under-the-hood. PEP8 compliance is also verified as part of the CI by `flake8`.
 As much python code in this repo as is feasible should include type annotations.
 These type annotations can then be ingested and checked by `mypy`, which can be
 run with `make typecheck` and `make checks`.
+
+## Docstrings
+
+As many public python interfaces in this repo as is feasible should include
+docstring documentation. All docstrings should follow the [numpy
+format](https://numpydoc.readthedocs.io/en/latest/format.html). These
+docstrings are automatically parsed by Sphinx and turned into html-based
+documentation hosted on readthedocs. Document generation can be run locally
+with `make docs`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,9 @@ All code should conform to [PEP8](https://www.python.org/dev/peps/pep-0008/).
 This compliance can be checked with `make stylecheck` or `make checks` and
 be automatically achieved by running `make style`, which runs `autopep8`
 under-the-hood. PEP8 compliance is also verified as part of the CI by `flake8`.
+
+## Type Annotations
+
+As much python code in this repo as is feasible should include type annotations.
+These type annotations can then be ingested and checked by `mypy`, which can be
+run with `make typecheck` and `make checks`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,16 +19,16 @@ details how to contribute in a standardized and efficient manner.
   and [start a new feature branch on your fork from
   that](https://matplotlib.org/stable/devel/gitwash/development_workflow.html#make-a-new-feature-branch).
 - Make a new branch for each separable set of changes — ["one task, one
-  branch"](https://mail.python.org/pipermail/ipython-dev/2010-October/005632.html)
+  branch"](https://mail.python.org/pipermail/ipython-dev/2010-October/005632.html).
 - [Each commit should make one change](https://dev.to/ruanbrandao/how-to-make-good-git-commits-256k).
   to aide reviewing and (in the worst case) simplify reverting it in the future.
   - A patch commit message should consist of a single short (less than 50
-    character) line summarizing the change, optionally followed by a blank line
+    character) sentence summarizing the change, optionally followed by a blank line
     and then a more thorough description.
   - Where applicable, a PR or commit message body should reference an Issue by
     number (e.g. `Fixes #33`).
-- If you can possibly avoid it, avoid merging upstream branches or any other
-  branches into your feature branch while you are working.
+- If possible, avoid merging upstream branches or any other branches into your
+  feature branch while you are working.
   - If you do find yourself merging from upstream, consider [Rebasing on
     upstream](https://matplotlib.org/stable/devel/gitwash/development_workflow.html#rebase-on-trunk).
 - Submit a Pull Request from your feature branch against upstream.

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ docs: genautodocs docs-noauto
 docs-noauto:
 	sphinx-build -W -b html docs docs/.build/
 
+.PHONY: style
+style:
+	autopep8 -i -r src tests
+
 
 LAUNCHER_SCRIPT_DIR := src/psi/j/launchers/scripts
 LAUNCHER_SCRIPT_TEMPLATES := $(wildcard $(LAUNCHER_SCRIPT_DIR)/*.sht)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ extensions = [
     'sphinx.ext.autodoc.typehints',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
 ]
 
 autodoc_typehints = "description"

--- a/requirements-connector-radical.txt
+++ b/requirements-connector-radical.txt
@@ -1,0 +1,2 @@
+radical.utils
+radical.pilot

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ sphinx-tabs
 mypy >=0.790
 pytest
 flake8
+autopep8

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+-r requirements-connector-radical.txt

--- a/src/psi/j/executors/rp.py
+++ b/src/psi/j/executors/rp.py
@@ -178,7 +178,7 @@ class RPJobExecutor(JobExecutor):
 
         :param job: The job to attach.
         :param native_id: The native ID of the process to attached to, as
-        obtained through :func:`~psi.j.executors.RPJobExecutor.list` method.
+            obtained through :func:`~psi.j.executors.RPJobExecutor.list` method.
         """
 
         if job.status.state != JobState.NEW:

--- a/src/psi/j/job_executor_config.py
+++ b/src/psi/j/job_executor_config.py
@@ -10,7 +10,7 @@ class JobExecutorConfig(object):
         Initializes a configuration object.
 
         :param launcher_log_file: If specified, log messages from launcher scripts (including
-        output from pre- and post- launch scripts) will be directed to this file.
+            output from pre- and post- launch scripts) will be directed to this file.
         """
         self.launcher_log_file = launcher_log_file
 

--- a/src/psi/j/launchers/script_based_launcher.py
+++ b/src/psi/j/launchers/script_based_launcher.py
@@ -19,10 +19,11 @@ class ScriptBasedLauncher(Launcher):
 
     This launcher is an abstract base class for launchers that wrap the job in a script. The script
     must be a bash script and is invoked with the first four parameters as:
-        - the job ID
-        - a launcher log file, which is taken from the launcher_log_file configuration setting and
-        defaults to `/dev/null`
-        - the pre- and post- launcher scripts, or empty strings if they are not specified
+
+    * the job ID
+    * a launcher log file, which is taken from the launcher_log_file configuration setting and
+      defaults to `/dev/null`
+    * the pre- and post- launcher scripts, or empty strings if they are not specified
 
     Additional positional arguments to the script can be specified by subclasses by overriding
     the :func:`~psi.j.launchers.script_based_launcher.ScriptBasedLauncher._get_additional_args`
@@ -32,14 +33,16 @@ class ScriptBasedLauncher(Launcher):
 
     A simple script library is provided in scripts/lib.sh. Its use is optional and it is intended
     to be included in a main launcher script using a standard C preprocessor. It does the following:
-        - sets '-e' mode (exit on error)
-        - sets the variables _PSI_J_JOB_ID, _PSI_J_LOG_FILE, _PSI_J_PRE_LAUNCH, and
-          _PSI_J_POST_LAUNCH from the first arguments, as specified above.
-        - saves the current stdout and stderr in descriptors 3 and 4, respectively
-        - redirects stdout and stderr to the log file, while pre-pending a timestamp and the
-          job ID to each line
-        - defines the commands "pre_launch" and "post_launch", which can be invoked by the main
-          script.
+
+    * sets '-e' mode (exit on error)
+    * sets the variables _PSI_J_JOB_ID, _PSI_J_LOG_FILE, _PSI_J_PRE_LAUNCH, and
+      _PSI_J_POST_LAUNCH from the first arguments, as specified above.
+    * saves the current stdout and stderr in descriptors 3 and 4, respectively
+    * redirects stdout and stderr to the log file, while pre-pending a timestamp and the
+      job ID to each line
+    * defines the commands "pre_launch" and "post_launch", which can be invoked by the main
+      script.
+
     When invoking the job executable (either directly or through a launch command), it is
     recommended that the stdout and stderr of the job process be redirected to descriptors 3 and 4,
     respectively, such that they can be captured by the entity invoking the launcher rather than


### PR DESCRIPTION
- Copy the CONTRIBUTING guide from the SDK repo
- add notes to CONTRIBUTING about the docstring format, type annotations, and code style
- add a make target for `autopep8`, add it to the dev-requirements.txt, and run it on the codebase
- fix `make docs` build due to docstring syntax errors

Closes #20
Closes #21
Closes #22
