### PR TITLE
Properly handle launcher errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ LAUNCHER_SCRIPTS := $(patsubst $(LAUNCHER_SCRIPT_DIR)/%.sht, $(LAUNCHER_SCRIPT_D
 .PHONY: launcher-scripts
 launcher-scripts: $(LAUNCHER_SCRIPTS)
 
-$(LAUNCHER_SCRIPT_DIR)/%.sh: $(LAUNCHER_SCRIPT_DIR)/%.sht
+$(LAUNCHER_SCRIPT_DIR)/%.sh: $(LAUNCHER_SCRIPT_DIR)/%.sht $(LAUNCHER_SCRIPT_DIR)/lib.sh
 	cpp -P $< $@
 
 .PHONY: install

--- a/src/psi/j/executors/local.py
+++ b/src/psi/j/executors/local.py
@@ -285,6 +285,11 @@ class LocalJobExecutor(JobExecutor):
         self._update_job_status(job, JobStatus(JobState.QUEUED, time=time.time()))
         self._update_job_status(job, JobStatus(JobState.ACTIVE, time=time.time()))
 
+    def _update_job_status(self, job: Job, job_status: JobStatus) -> None:
+        job._set_status(job_status, self)
+        if self._cb:
+            self._cb.job_status_changed(job, job_status)
+
     def _get_launcher_name(self, spec: JobSpec) -> str:
         if spec.launcher is None:
             return 'single'

--- a/src/psi/j/launchers/launcher.py
+++ b/src/psi/j/launchers/launcher.py
@@ -33,6 +33,43 @@ class Launcher(ABC):
         """
         pass
 
+    @abstractmethod
+    def is_launcher_failure(self, output: str) -> bool:
+        """
+        Determines whether the launcher invocation output contains a launcher failure or not.
+
+        Parameters
+        ----------
+        output
+            The output (combined stdout/stderr) from an invocation of the launcher command
+
+        Returns
+        -------
+            Returns `True` if the output
+
+        """
+        pass
+
+    @abstractmethod
+    def get_launcher_failure_message(self, output: str) -> str:
+        """
+        Extracts the launcher error message from the output of this launcher's invocation.
+
+        It is understood that the output is such that
+        :func:`~psi.j.laucnhers.launcher.Launcher.is_launcher_failure` returns `True` on it.
+
+        Parameters
+        ----------
+        output
+            The output (combined stdout/stderr) from an invocation of the launcher command.
+
+        Returns
+        -------
+            A string representing the part of the launcher output that describes the launcher
+            error.
+        """
+        pass
+
     @staticmethod
     def get_instance(name: str, config: Optional[JobExecutorConfig] = None) -> 'Launcher':
         """

--- a/src/psi/j/launchers/script_based_launcher.py
+++ b/src/psi/j/launchers/script_based_launcher.py
@@ -13,6 +13,13 @@ def _str(obj: Optional[object]) -> str:
         return ''
 
 
+def _path(obj: Optional[object]) -> str:
+    if obj is None:
+        return '/dev/null'
+    else:
+        return str(obj)
+
+
 class ScriptBasedLauncher(Launcher):
     """
     A launcher that uses a script to start the job, possibly by wrapping it in other tools.
@@ -65,7 +72,8 @@ class ScriptBasedLauncher(Launcher):
         assert spec is not None
 
         args = ['/bin/bash', str(self._script_path), job.id, _str(self._log_file),
-                _str(spec.pre_launch), _str(spec.post_launch)]
+                _str(spec.pre_launch), _str(spec.post_launch), _path(spec.stdin_path),
+                _path(spec.stdout_path), _path(spec.stderr_path)]
         args += self._get_additional_args(job)
         assert spec.executable is not None
         args += [spec.executable]
@@ -81,3 +89,11 @@ class ScriptBasedLauncher(Launcher):
         :param job: The job that is being launched.
         """
         return []
+
+    def is_launcher_failure(self, output: str) -> bool:
+        """See :func:`~psi.j.launchers.launcher.Launcher.is_launcher_failure`."""
+        return output.split('\n')[-1] != '_PSI_J_LAUNCHER_DONE'
+
+    def get_launcher_failure_message(self, output: str) -> str:
+        """See :func:`~psi.j.launchers.launcher.Launcher.get_launcher_failure_message`."""
+        return '\n'.join(output.split('\n')[:-1])

--- a/src/psi/j/launchers/scripts/lib.sh
+++ b/src/psi/j/launchers/scripts/lib.sh
@@ -5,6 +5,13 @@ set -e
 
 _PSI_J_JOB_ID="$1"
 _PSI_J_LOG_FILE="$2"
+_PSI_J_PRE_LAUNCH="$3"
+_PSI_J_POST_LAUNCH="$4"
+_PSI_J_STDIN="$5"
+_PSI_J_STDOUT="$6"
+_PSI_J_STDERR="$7"
+
+shift 7
 
 if [ "$_PSI_J_LOG_FILE" == "" ]; then
     _PSI_J_LOG_FILE="/dev/null"
@@ -17,26 +24,28 @@ ts() {
     done
 }
 
-// Save out and err to FDs 3 and 4, and redirect out and err to log file
-exec 3>&1 4>&2 > >(ts >> "$_PSI_J_LOG_FILE") 2>&1
+log() {
+    echo "$@" >&3
+}
+exec 3> >(ts >> "$_PSI_J_LOG_FILE")
 
-_PSI_J_PRE_LAUNCH="$3"
-_PSI_J_POST_LAUNCH="$4"
-shift 4
-
-echo "Pre-launch: \"$_PSI_J_PRE_LAUNCH\""
-echo "Post-launch: \"$_PSI_J_POST_LAUNCH\""
+log "Pre-launch: \"$_PSI_J_PRE_LAUNCH\""
+log "Post-launch: \"$_PSI_J_POST_LAUNCH\""
 
 pre_launch() {
     if [ "$_PSI_J_PRE_LAUNCH_" != "" ]; then
-        echo "Running pre-launch"
+        log "Running pre-launch"
+        exec 4>&1 5>&2
         source "$_PSI_J_PRE_LAUNCH_"
+        exec 1>&4 2>&5 4>&- 5>&-
     fi
 }
 
 post_launch() {
     if [ "$_PSI_J_POST_LAUNCH_" != "" ]; then
-        echo "Running post-launch"
+        log "Running post-launch"
+        exec 4>&1 5>&2
         source "$_PSI_J_POST_LAUNCH_"
+        exec 1>&4 2>&5 4>&- 5>&-
     fi
 }

--- a/src/psi/j/launchers/scripts/mpi_launch.sht
+++ b/src/psi/j/launchers/scripts/mpi_launch.sht
@@ -5,10 +5,11 @@ shift
 
 pre_launch
 
-mpirun -n $_PSI_J_PROCESS_COUNT "$@" 1>&3 2>&4
+mpirun -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN
 _PSI_J_EC=$?
-echo "Command done: $_PSI_J_EC"
+log "Command done: $_PSI_J_EC"
 
 post_launch
 
+echo "_PSI_J_LAUNCHER_DONE"
 exit $_PSI_J_EC

--- a/src/psi/j/launchers/scripts/multi_launch.sht
+++ b/src/psi/j/launchers/scripts/multi_launch.sht
@@ -8,7 +8,7 @@ shift
 export _PSI_J_PROCESS_COUNT_
 
 for INDEX in $(seq 1 1 $_PSI_J_PROCESS_COUNT_); do
-    _PSI_J_PROCESS_INDEX_=$INDEX "$@" 1>&3 2>&4 &
+    _PSI_J_PROCESS_INDEX_=$INDEX "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR  <$_PSI_J_STDIN &
     PIDS="$PIDS $!"
 done
 
@@ -16,13 +16,14 @@ for PID in $PIDS ; do
     wait $PID
     _PSI_J_EC=$?
     if [ "$_PSI_J_EC" != "0" ]; then
-        echo "Pid $PID failed with $_PSI_J_EC"
+        log "Pid $PID failed with $_PSI_J_EC"
         _PSI_J_FAILED_EC=$_PSI_J_EC
     fi
 done
 
-echo "All completed"
+log "All completed"
 
 post_launch
 
+echo "_PSI_J_LAUNCHER_DONE"
 exit $_PSI_J_FAILED_EC

--- a/src/psi/j/launchers/scripts/single_launch.sht
+++ b/src/psi/j/launchers/scripts/single_launch.sht
@@ -2,10 +2,11 @@
 
 pre_launch
 
-"$@" 1>&3 2>&4
+"$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR  <$_PSI_J_STDIN
 _PSI_J_EC=$?
-echo "Command done: $_PSI_J_EC"
+log "Command done: $_PSI_J_EC"
 
 post_launch
 
+echo "_PSI_J_LAUNCHER_DONE"
 exit $_PSI_J_EC


### PR DESCRIPTION
Commit 47ce6db describes the general problem in more detail.

In addition, this PR removes comments in launcher script templates. The templates are processed with the C pre-processor. On linux with somewhat recent versions of GCC, the default behavior is to remove comments from the output. On OS X, the default `cpp` seems to be the LLVM clang compiler, which keeps comments after pre-processing. These comments, however, are not valid comments in a script. So this should also fix #25.

