### PR TITLE
Remove gcc dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,22 +40,14 @@ style:
 	autopep8 -i -r src tests
 
 
-LAUNCHER_SCRIPT_DIR := src/psi/j/launchers/scripts
-LAUNCHER_SCRIPT_TEMPLATES := $(wildcard $(LAUNCHER_SCRIPT_DIR)/*.sht)
-LAUNCHER_SCRIPTS := $(patsubst $(LAUNCHER_SCRIPT_DIR)/%.sht, $(LAUNCHER_SCRIPT_DIR)/%.sh, $(LAUNCHER_SCRIPT_TEMPLATES))
-
-
-
 .PHONY: launcher-scripts
-launcher-scripts: $(LAUNCHER_SCRIPTS)
-
-$(LAUNCHER_SCRIPT_DIR)/%.sh: $(LAUNCHER_SCRIPT_DIR)/%.sht $(LAUNCHER_SCRIPT_DIR)/lib.sh
-	cpp -P $< $@
+launcher-scripts:
+	$(PYTHON) setup.py launcher-scripts
 
 .PHONY: install
-install: launcher-scripts
+install:
 	$(PYTHON) setup.py install
 
 .PHONY: develop
-develop: launcher-scripts
+develop:
 	$(PYTHON) setup.py develop

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ style:
 
 .PHONY: launcher-scripts
 launcher-scripts:
-	$(PYTHON) setup.py launcher-scripts
+	$(PYTHON) setup.py launcher_scripts
 
 .PHONY: install
 install:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class BuildLauncherScriptsCommand(Command):
 class CustomBuildCommand(build):
     def run(self) -> None:
         # build launcher scripts first
-        BuildLauncherScriptsCommand().run()
+        BuildLauncherScriptsCommand(self.distribution).run()
         super().run()
 
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
         ],
 
 
-        packages=['psi'],
+        packages=find_packages(where='src'),
         package_dir={'': 'src'},
 
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
 
         package_data={
             '': ['README.md', 'LICENSE'],
-            'psi-j-python': ['*.sh']
+            'psi': ['j/launchers/scripts/*.sh']
         },
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,13 @@ if __name__ == '__main__':
 
         url='https://github.com/exaworks/psi-j-python',
 
-        classifiers=(
+        classifiers=[
             'Programming Language :: Python :: 3',
             'License :: OSI Approved :: MIT License',
-        ),
+        ],
 
 
-        packages=setuptools.find_packages(where='src'),
+        packages=['psi'],
         package_dir={'': 'src'},
 
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,52 @@
+import distutils
+import io
+import pathlib
+
 from setuptools import setup, find_packages
+from distutils.cmd import Command
+from distutils.command.build import build
+
+
+class BuildLauncherScriptsCommand(Command):
+
+    description = '''Build the launcher scripts'''
+    user_options = []
+
+    def initialize_options(self) -> None:
+        pass
+
+    def finalize_options(self) -> None:
+        pass
+
+    def run(self) -> None:
+        dir = pathlib.Path(self._get_script_dir())
+        for file in dir.iterdir():
+            if file.suffix == '.sht':
+                self._build_script(file)
+
+    def _get_script_dir(self) -> str:
+        return 'src/psi/j/launchers/scripts'
+
+    def _build_script(self, template_path: pathlib.Path) -> None:
+        lib_path = template_path.with_name('lib.sh')
+        dest_path = template_path.with_suffix('.sh')
+
+        with dest_path.open('w') as dest:
+            self._append(dest, lib_path)
+            self._append(dest, template_path)
+
+    def _append(self, dest: io.TextIOBase, src_path: pathlib.Path) -> None:
+        with src_path.open('r') as src:
+            for line in src:
+                dest.write(line)
+
+
+class CustomBuildCommand(build):
+    def run(self) -> None:
+        # build launcher scripts first
+        BuildLauncherScriptsCommand().run()
+        super().run()
+
 
 if __name__ == '__main__':
     setup(
@@ -36,4 +84,9 @@ if __name__ == '__main__':
         install_requires=[
         ],
         python_requires='>=3.6',
+
+        cmdclass={
+            'launcher_scripts': BuildLauncherScriptsCommand,
+            'build': CustomBuildCommand,
+        },
     )

--- a/src/psi/j/launchers/scripts/lib.sh
+++ b/src/psi/j/launchers/scripts/lib.sh
@@ -1,5 +1,4 @@
-#define _HASH_ #
-#define _BIN_BASH_ #!/bin/bash
+#!/bin/bash
 
 set -e
 

--- a/src/psi/j/launchers/scripts/mpi_launch.sht
+++ b/src/psi/j/launchers/scripts/mpi_launch.sht
@@ -1,4 +1,4 @@
-#include "lib.sh"
+# <lib.sh>
 
 _PSI_J_PROCESS_COUNT_="$1"
 shift

--- a/src/psi/j/launchers/scripts/multi_launch.sht
+++ b/src/psi/j/launchers/scripts/multi_launch.sht
@@ -1,4 +1,4 @@
-#include "lib.sh"
+# <lib.sh>
 
 pre_launch
 

--- a/src/psi/j/launchers/scripts/single_launch.sht
+++ b/src/psi/j/launchers/scripts/single_launch.sht
@@ -1,4 +1,4 @@
-#include "lib.sh"
+# <lib.sh>
 
 pre_launch
 


### PR DESCRIPTION
The launcher scripts are now generated during `setup.py build` and the generation happens in `setup.py`, which also gets a new command named `launcher-scripts`. The `Makefile` target with the same name remains, but now points to `setup.py`.