### PR TITLE
Fix `version` accessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ psi_j_python.egg-info/
 
 venv*
 .venv*
+build/

--- a/src/psi/j/job_executor.py
+++ b/src/psi/j/job_executor.py
@@ -66,7 +66,7 @@ class JobExecutor(ABC):
     @property
     def version(self) -> Version:
         """Returns the version of this executor."""
-        return cast(Version, getattr(self.__class__, '__VERSION__'))
+        return cast(Version, getattr(self.__class__, '_VERSION_'))
 
     @abstractmethod
     def submit(self, job: Job) -> None:

--- a/tests/test_executor_versions.py
+++ b/tests/test_executor_versions.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+# This is meant as a simple test file to check if psi/j was installed successfully
+
+from distutils.version import Version
+
+from psi.j import JobExecutor
+
+
+def test_executor_version(name: str = 'local') -> None:
+    exec = JobExecutor.get_instance(name)
+    assert isinstance(exec.version, Version)


### PR DESCRIPTION
Fix executors' `version` property getter.

Oh, and I snuck a gitignore change in since `make` creates a `build` directory that git wants to track by default.

Closes #41 