### PR TITLE
Fix JobSpec.attributes default

### DIFF
--- a/src/psij/job_spec.py
+++ b/src/psij/job_spec.py
@@ -61,7 +61,7 @@ class JobSpec(object):
         self.stdout_path = stdout_path
         self.stderr_path = stderr_path
         self.resources = resources
-        self.attributes = attributes
+        self.attributes = attributes if attributes is not None else JobAttributes()
         self.pre_launch = pre_launch
         self.post_launch = post_launch
         self.launcher = launcher


### PR DESCRIPTION
closes #59. The default attributes now make it into generated batch scripts. At the moment the only default is walltime, so we get something like 

```
#!/bin/bash



#BSUB -env all



#BSUB -W 10






#BSUB -e /dev/null
#BSUB -o /dev/null

exec &>> "/g/g12/corbett8/.psij/work/lsf/$LSB_JOBID.out"
```

Instead of 

```
#!/bin/bash



#BSUB -env all



#BSUB -e /dev/null
#BSUB -o /dev/null

exec &>> "/g/g12/corbett8/.psij/work/lsf/$LSB_JOBID.out"

/bin/bash /usr/WS2/corbett8/37B/lib/python3.7/site-packages/psij/launchers/scripts/single_launch.sh a7c0891a-0818-4e0a-b99d-055f38dea296 '' '' '' /dev/null /dev/null /dev/null /bin/false 

echo "$?" > "/g/g12/corbett8/.psij/work/lsf/$LSB_JOBID.ec"
```