### PR TITLE
Add Cobalt executor

### DIFF
--- a/src/psij/executors/__init__.py
+++ b/src/psij/executors/__init__.py
@@ -4,5 +4,12 @@ from .local import LocalJobExecutor
 from .rp import RPJobExecutor
 from .flux import FluxJobExecutor
 from .lsf import LsfJobExecutor
+from .cobalt import CobaltJobExecutor
 
-__all__ = ['LocalJobExecutor', 'RPJobExecutor', 'FluxJobExecutor', 'LsfJobExecutor']
+__all__ = [
+    'LocalJobExecutor',
+    'RPJobExecutor',
+    'FluxJobExecutor',
+    'LsfJobExecutor',
+    'CobaltJobExecutor'
+]

--- a/src/psij/executors/batch/cobalt/cobalt.mustache
+++ b/src/psij/executors/batch/cobalt/cobalt.mustache
@@ -1,0 +1,43 @@
+#!/bin/bash
+{{#job.name}}
+#COBALT --jobname={{.}}
+{{/job.name}}
+{{#job.spec.directory}}
+#COBALT --cwd={{.}}
+{{/job.spec.directory}}
+{{#job.spec.resources}}
+    {{#node_count}}
+#COBALT --nodecount={{.}}
+    {{/node_count}}
+    {{#process_count}}
+#COBALT --proccount={{.}}
+    {{/process_count}}
+{{/job.spec.resources}}
+{{#job.spec.attributes}}
+    {{#duration}}
+#COBALT --time={{duration}}
+    {{/duration}}
+    {{#queue_name}}
+#COBALT --queue={{.}}
+    {{/queue_name}}
+    {{#project_name}}
+#COBALT --project={{.}}
+    {{/project_name}}
+    {{#custom_attributes.COBALT}}
+#COBALT --{{key}}="{{value}}"
+    {{/custom_attributes.COBALT}}
+{{/job.spec.attributes}}
+{{!since we redirect the output manually, below, tell COBALT not to do its own thing, since it
+only results in empty files that are not cleaned up}}
+#COBALT -e /dev/null
+#COBALT -o /dev/null
+
+{{!redirect output here instead of through #COBALT directive since COBALT_JOB_ID is not available
+when the directives are evaluated; the reason for using the job id in the first place being the
+same as for the exit code file.}}
+exec &>> "{{psij.script_dir}}/$COBALT_JOBID.out"
+
+{{#psij.launch_command}}{{.}} {{/psij.launch_command}}
+
+{{!we redirect to a file tied to the native ID so that we can reach the file with attach().}}
+echo "$?" > "{{psij.script_dir}}/$COBALT_JOBID.ec"

--- a/src/psij/executors/batch_test.py
+++ b/src/psij/executors/batch_test.py
@@ -5,7 +5,7 @@ from typing import Optional, Collection, List, Dict, TextIO
 
 from psij import Job, JobStatus, JobState, SubmitException
 from psij.executors.batch.batch_scheduler_executor import BatchSchedulerExecutor, \
-    BatchSchedulerExecutorConfig, _InvalidJobStateError
+    BatchSchedulerExecutorConfig, _InvalidJobStateError, check_status_exit_code
 from psij.executors.batch.script_generator import TemplatedScriptGenerator
 
 
@@ -72,7 +72,8 @@ class _TestJobExecutor(BatchSchedulerExecutor):
     def job_id_from_submit_output(self, out: str) -> str:
         return out.strip().split()[-1]
 
-    def parse_status_output(self, out: str) -> Dict[str, JobStatus]:
+    def parse_status_output(self, exit_code: int, out: str) -> Dict[str, JobStatus]:
+        check_status_exit_code(QSTAT_PATH, exit_code, out)
         r = {}
         lines = iter(out.split('\n'))
         for line in lines:

--- a/src/psij/executors/cobalt.py
+++ b/src/psij/executors/cobalt.py
@@ -1,0 +1,109 @@
+"""Defines a JobExecutor for the Cobalt resource manager."""
+
+from distutils.version import StrictVersion
+from pathlib import Path
+from typing import Optional, Collection, List, Dict, TextIO
+import re
+import os
+import stat
+
+from psij import Job, JobStatus, JobState, SubmitException
+from psij.executors.batch.batch_scheduler_executor import (
+    BatchSchedulerExecutor,
+    BatchSchedulerExecutorConfig,
+)
+from psij.executors.batch.script_generator import TemplatedScriptGenerator
+
+
+_QSTAT_STATE_REGEX = re.compile(r"(State\s*:\s*)(\w+)", re.IGNORECASE)
+_QSTAT_JOBID_REGEX = re.compile(r"(Jobid\s*:\s*)([0-9]{4,})", re.IGNORECASE)
+_QSUB_REGEX = re.compile(r"\b[0-9]{4,}\b", re.IGNORECASE)
+
+
+class CobaltExecutorConfig(BatchSchedulerExecutorConfig):
+    """A configuration class for the Cobalt executor."""
+
+
+class CobaltJobExecutor(BatchSchedulerExecutor):
+    """A :proc:`~psij.JobExecutor` for the Cobalt Workload Manager."""
+
+    _NAME_ = "cobalt"
+    _VERSION_ = StrictVersion("0.0.1")
+
+    # see https://Cobalt.schedmd.com/squeue.html
+    _STATE_MAP = {
+        "starting": JobState.ACTIVE,
+        "queued": JobState.QUEUED,
+        "running": JobState.ACTIVE,
+        "exiting": JobState.ACTIVE,
+        "killing": JobState.FAILED,
+    }
+
+    def __init__(
+        self, url: Optional[str] = None, config: Optional[CobaltExecutorConfig] = None
+    ):
+        """Initializes a :proc:`~CobaltJobExecutor`."""
+        if not config:
+            config = CobaltExecutorConfig()
+        super().__init__(config=config)
+        self.generator = TemplatedScriptGenerator(
+            config, Path(__file__).parent / "batch" / "cobalt" / "cobalt.mustache"
+        )
+
+    def generate_submit_script(
+        self, job: Job, context: Dict[str, object], submit_file: TextIO
+    ) -> None:
+        """See :proc:`~BatchSchedulerExecutor.generate_submit_script`."""
+        self.generator.generate_submit_script(job, context, submit_file)
+
+    def get_submit_command(self, job: Job, submit_file_path: Path) -> List[str]:
+        """See :proc:`~BatchSchedulerExecutor.get_submit_command`."""
+        str_path = str(submit_file_path.absolute())
+        os.chmod(str_path, os.stat(str_path).st_mode | stat.S_IEXEC)
+        return ["qsub", str_path]
+
+    def get_cancel_command(self, native_id: str) -> List[str]:
+        """See :proc:`~BatchSchedulerExecutor.get_cancel_command`."""
+        return ["qdel", native_id]
+
+    def process_cancel_command_output(self, exit_code: int, out: str) -> None:
+        """See :proc:`~BatchSchedulerExecutor.process_cancel_command_output`.
+
+        This should be unnecessary because `qdel` only seems to fail on
+        non-integer job IDs.
+        """
+        raise SubmitException("Failed job cancel job: %s" % out)
+
+    def get_status_command(self, native_ids: Collection[str]) -> List[str]:
+        """See :proc:`~BatchSchedulerExecutor.get_status_command`."""
+        return ["qstat", "-l", "--header=Jobid:State", *native_ids]
+
+    def parse_status_output(self, out: str) -> Dict[str, JobStatus]:
+        """See :proc:`~BatchSchedulerExecutor.parse_status_output`."""
+        job_statuses = {}
+        index = 0
+        lines = out.split("\n")
+        while index < len(lines) - 1:
+            jobid_match = _QSTAT_JOBID_REGEX.search(lines[index])
+            if jobid_match is not None:
+                state_match = _QSTAT_STATE_REGEX.search(lines[index + 1])
+                if state_match is not None:
+                    job_statuses[jobid_match.group(2)] = JobStatus(
+                        self._STATE_MAP[state_match.group(2)]
+                    )
+                    index += 2
+                else:
+                    index += 1
+            else:
+                index += 1
+        return job_statuses
+
+    def job_id_from_submit_output(self, out: str) -> str:
+        """See :proc:`~BatchSchedulerExecutor.job_id_from_submit_output`."""
+        match = _QSUB_REGEX.search(out)
+        if match is None:
+            raise SubmitException(out)
+        return match.group(0)
+
+
+__PSI_J_EXECUTORS__ = [CobaltJobExecutor]

--- a/src/psij/executors/cobalt.py
+++ b/src/psij/executors/cobalt.py
@@ -11,6 +11,8 @@ from psij import Job, JobStatus, JobState, SubmitException
 from psij.executors.batch.batch_scheduler_executor import (
     BatchSchedulerExecutor,
     BatchSchedulerExecutorConfig,
+    UNKNOWN_ERROR,
+    check_status_exit_code,
 )
 from psij.executors.batch.script_generator import TemplatedScriptGenerator
 
@@ -18,7 +20,7 @@ from psij.executors.batch.script_generator import TemplatedScriptGenerator
 _QSTAT_STATE_REGEX = re.compile(r"(State\s*:\s*)(\w+)", re.IGNORECASE)
 _QSTAT_JOBID_REGEX = re.compile(r"(Jobid\s*:\s*)([0-9]{4,})", re.IGNORECASE)
 _QSUB_REGEX = re.compile(r"\b[0-9]{4,}\b", re.IGNORECASE)
-
+_QSTAT_COMMAND = "qstat"
 
 class CobaltExecutorConfig(BatchSchedulerExecutorConfig):
     """A configuration class for the Cobalt executor."""
@@ -76,10 +78,15 @@ class CobaltJobExecutor(BatchSchedulerExecutor):
 
     def get_status_command(self, native_ids: Collection[str]) -> List[str]:
         """See :proc:`~BatchSchedulerExecutor.get_status_command`."""
-        return ["qstat", "-l", "--header=Jobid:State", *native_ids]
+        return [_QSTAT_COMMAND, "-l", "--header=Jobid:State", *native_ids]
 
-    def parse_status_output(self, out: str) -> Dict[str, JobStatus]:
+    def parse_status_output(self, exit_code: int, out: str) -> Dict[str, JobStatus]:
         """See :proc:`~BatchSchedulerExecutor.parse_status_output`."""
+        # if none of the job ID passed to Cobalt are recognized, qstat returns 1,
+        # but we shouldn't treat that as an error
+        if exit_code != 0 and out == UNKNOWN_ERROR:
+            return {}
+        check_status_exit_code(_QSTAT_COMMAND, exit_code, out)
         job_statuses = {}
         index = 0
         lines = out.split("\n")


### PR DESCRIPTION
Adds a Cobalt executor. There are a fair number of PSI/J options not currently implemented/supported in the mustache script. A big one is the environment inheritance. I don't have much of an account on ALCF or much experience with Cobalt so help debugging/testing would be great.

At the moment I get:
```
Polling error: Failed to poll for job status. Error from status command: Unknown error
Polling error: Failed to poll for job status. Error from status command: Unknown error
Polling error: Failed to poll for job status. Error from status command: Unknown error
Success job finished with JobStatus[FAILED, time=1634951694.098435, message=Failed to poll for job status. Error from status command: Unknown error]
```

Not very helpful...

We will also need a Cobalt launcher (#58).