### PR TITLE
Fix mypy typing errors with Flux and LSF executors

### DIFF
--- a/src/psij/executors/flux.py
+++ b/src/psij/executors/flux.py
@@ -26,15 +26,6 @@ class FluxJobExecutor(JobExecutor):
     A job executor that runs jobs via Flux.
     """
 
-    try:
-        import radical.utils as _ru
-    except ImportError:
-        _ru = None
-    try:
-        import flux as _flux
-    except ImportError:
-        _flux = None
-
     _NAME_ = 'flux'
     _VERSION_ = StrictVersion('0.0.1')
 
@@ -66,10 +57,10 @@ class FluxJobExecutor(JobExecutor):
         # TODO: url is not passed
         # if not url.startswith('flux://'):
         #     raise ValueError('expected `flux://` url')
-        if self._flux is None:
-            raise ImportError("required package 'flux' not available")
-        if self._ru is None:
-            raise ImportError("required package 'radical.utils' not available")
+        import radical.utils as _ru
+        import flux as _flux
+        self._flux = _flux
+        self._ru = _ru
 
         super().__init__(url=url, config=config)
 

--- a/src/psij/executors/lsf.py
+++ b/src/psij/executors/lsf.py
@@ -58,6 +58,7 @@ class LsfJobExecutor(BatchSchedulerExecutor):
         self, job: Job, context: Dict[str, object], submit_file: TextIO
     ) -> None:
         """See :proc:`~BatchSchedulerExecutor.generate_submit_script`."""
+        assert(job.spec is not None)
         context["job_duration"] = int(job.spec.attributes.duration.total_seconds() // 60)
         self.generator.generate_submit_script(job, context, submit_file)
 
@@ -83,14 +84,13 @@ class LsfJobExecutor(BatchSchedulerExecutor):
 
     def get_status_command(self, native_ids: Collection[str]) -> List[str]:
         """See :proc:`~BatchSchedulerExecutor.get_status_command`."""
-        jobids = [str(jobid) for jobid in native_ids]
         return [
             "bjobs",
             "-o",
             "JOBID STAT EXIT_REASON KILL_REASON SUSPEND_REASON",
             "-json",
             "-a",
-            *jobids,
+            *native_ids,
         ]
 
     def parse_status_output(self, out: str) -> Dict[str, JobStatus]:


### PR DESCRIPTION
Fixes typing errors I introduced in #56 and #61 . (Also removes one redundant line of code).