### PR TITLE
Logging times in utc

### DIFF
--- a/src/psij/launchers/scripts/lib.sh
+++ b/src/psij/launchers/scripts/lib.sh
@@ -18,7 +18,7 @@ fi
 
 ts() {
     while read LINE; do
-        printf -v TS "%(%F %T%z)T" -1
+        TZ=UTC printf -v TS "%(%F %T)T" -1
         echo "$TS $_PSI_J_JOB_ID $LINE"
     done
 }
@@ -28,7 +28,7 @@ log() {
 }
 exec 3> >(ts >> "$_PSI_J_LOG_FILE")
 
-
+log "Launcher: $0"
 log "Pre-launch: \"$_PSI_J_PRE_LAUNCH\""
 log "Post-launch: \"$_PSI_J_POST_LAUNCH\""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import shutil
 import socket
 import subprocess
 import threading
+import time
 from functools import partial
 from pathlib import Path
 from typing import Dict, List
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 LOG_FORMATTER = logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)s\n',
                                   datefmt='%Y-%m-%d %H:%M:%S')
+LOG_FORMATTER.converter = time.gmtime
 SETTINGS_DIR = Path.home() / '.psij'
 KEY_FILE = SETTINGS_DIR / '.key'
 ID_FILE = SETTINGS_DIR / '.id'


### PR DESCRIPTION
This applies to launcher logs and logs when running tests. We may want to have the launcher logs follow whatever timezone is used for the normal logs in the future.