### PR TITLE
Fix installation bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import pathlib
 
 from setuptools import setup, find_packages, Command
 from setuptools.command.develop import develop
-from setuptools.command.install import install
+from setuptools.command.build_py import build_py
 
 
 class BuildLauncherScriptsCommand(Command):
@@ -42,15 +42,15 @@ class BuildLauncherScriptsCommand(Command):
 
 
 class CustomDevelopCommand(develop):
-    """Post-installation for development mode."""
+    """Create launcher scripts when building the code for development."""
 
     def run(self):
         BuildLauncherScriptsCommand(self.distribution).run()
         super().run()
 
 
-class CustomInstallCommand(install):
-    """Post-installation for installation mode."""
+class CustomBuildPyCommand(build_py):
+    """Create launcher scripts when building the code for installation."""
 
     def run(self):
         BuildLauncherScriptsCommand(self.distribution).run()
@@ -98,7 +98,7 @@ if __name__ == '__main__':
 
         cmdclass={
             'launcher_scripts': BuildLauncherScriptsCommand,
-            'install': CustomInstallCommand,
+            'build_py': CustomBuildPyCommand,
             'develop': CustomDevelopCommand,
         },
     )


### PR DESCRIPTION
Fixes the issue @benclifford found [here](https://github.com/ExaWorks/psi-j-python/pull/70#issuecomment-963232614).

When pip-installing the package from a clean repository, the
launcher scripts were not moved into the install directory.
This likely has to do with the timing of the 'install' class's
'run' method (i.e. that method probably runs after all files are
expected to be built). If you install twice, the launcher scripts
will be present from the first install, and so everything will
work as expected---this is why a clean repository is necessary
to reproduce the issue.

Resolve the problem by moving the script-building into the
build_py command.

Development installs (``pip install -e``) don't have this issue because there isn't any install directory to move the scripts to.