### PR TITLE
Removed the silly launcher building and replaced with on-demand deplo…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ CWD = $(shell pwd)
 PYTHON = $(shell if python --version 2>&1 | egrep -q 'Python 3\..*' ; then echo "python"; else echo "python3"; fi)
 
 .PHONY: tests
-tests: launcher-scripts
+tests:
 	PYTHONPATH=$(CWD)/src:${PYTHONPATH} ${PYTHON} -m pytest -v $(TESTARGS)
 
 .PHONY: verbose-tests
-verbose-tests: launcher-scripts
+verbose-tests:
 	PYTHONPATH=$(CWD)/src:${PYTHONPATH} ${PYTHON} -m pytest -v --log-format="%(asctime)s %(levelname)s %(message)s" \
 		           --log-date-format="%Y-%m-%d %H:%M:%S" --log-cli-level=DEBUG
 
@@ -43,10 +43,6 @@ docs:
 style:
 	autopep8 -i -r src tests
 
-
-.PHONY: launcher-scripts
-launcher-scripts:
-	$(PYTHON) setup.py launcher_scripts
 
 .PHONY: install
 install:

--- a/setup.py
+++ b/setup.py
@@ -1,60 +1,4 @@
-import distutils
-import io
-import pathlib
-
-from setuptools import setup, find_packages, Command
-from setuptools.command.develop import develop
-from setuptools.command.install import install
-
-
-class BuildLauncherScriptsCommand(Command):
-
-    description = '''Build the launcher scripts'''
-    user_options = []
-
-    def initialize_options(self) -> None:
-        pass
-
-    def finalize_options(self) -> None:
-        pass
-
-    def run(self) -> None:
-        dir = pathlib.Path(self._get_script_dir()).resolve(strict=True)
-        for file in dir.iterdir():
-            if file.suffix == '.sht':
-                self._build_script(file)
-
-    def _get_script_dir(self) -> str:
-        return 'src/psij/launchers/scripts'
-
-    def _build_script(self, template_path: pathlib.Path) -> None:
-        lib_path = template_path.with_name('lib.sh')
-        dest_path = template_path.with_suffix('.sh')
-
-        with dest_path.open('w') as dest:
-            self._append(dest, lib_path)
-            self._append(dest, template_path)
-
-    def _append(self, dest: io.TextIOBase, src_path: pathlib.Path) -> None:
-        with src_path.open('r') as src:
-            for line in src:
-                dest.write(line)
-
-
-class CustomDevelopCommand(develop):
-    """Post-installation for development mode."""
-
-    def run(self):
-        BuildLauncherScriptsCommand(self.distribution).run()
-        super().run()
-
-
-class CustomInstallCommand(install):
-    """Post-installation for installation mode."""
-
-    def run(self):
-        BuildLauncherScriptsCommand(self.distribution).run()
-        super().run()
+from setuptools import setup, find_packages
 
 
 if __name__ == '__main__':
@@ -94,11 +38,5 @@ if __name__ == '__main__':
 
         install_requires=[
         ],
-        python_requires='>=3.6',
-
-        cmdclass={
-            'launcher_scripts': BuildLauncherScriptsCommand,
-            'install': CustomInstallCommand,
-            'develop': CustomDevelopCommand,
-        },
+        python_requires='>=3.6'
     )

--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -31,8 +31,6 @@ class BatchSchedulerExecutorConfig(JobExecutorConfig):
     from this class should be defined, even if empty.
     """
 
-    DEFAULT_WORK_DIRECTORY = Path.home() / '.psij' / 'work'
-
     def __init__(self, launcher_log_file: Optional[Path] = None,
                  work_directory: Optional[Path] = None, queue_polling_interval: int = 30,
                  initial_queue_polling_delay: int = 2,
@@ -45,10 +43,7 @@ class BatchSchedulerExecutorConfig(JobExecutorConfig):
         launcher_log_file
             See :func:`~JobExecutorConfig.__init__`.
         work_directory
-            A directory where submit scripts and auxiliary job files will be generated. In a,
-            cluster this directory needs to point to a directory on a shared filesystem. This is so
-            that the exit code file, likely written on a service node, can be accessed by PSI/J,
-            likely running on a head node.
+            See :func:`~JobExecutorConfig.__init__`.
         queue_polling_interval
             an interval, in seconds, at which the batch scheduler queue will be polled for updates
             to jobs.
@@ -63,11 +58,7 @@ class BatchSchedulerExecutorConfig(JobExecutorConfig):
             Whether to keep submit files and auxiliary job files (exit code and output files) after
             a job has completed.
         """
-        super().__init__(launcher_log_file)
-        if work_directory:
-            self.work_directory = work_directory
-        else:
-            self.work_directory = BatchSchedulerExecutorConfig.DEFAULT_WORK_DIRECTORY
+        super().__init__(work_directory, launcher_log_file)
         self.queue_polling_interval = queue_polling_interval
         self.initial_queue_polling_delay = initial_queue_polling_delay
         self.queue_polling_error_threshold = queue_polling_error_threshold

--- a/src/psij/job_executor_config.py
+++ b/src/psij/job_executor_config.py
@@ -7,14 +7,29 @@ class JobExecutorConfig(object):
 
     DEFAULT: 'JobExecutorConfig' = None  # type: ignore
 
-    def __init__(self, launcher_log_file: Optional[Path] = None):
+    DEFAULT_WORK_DIRECTORY = Path.home() / '.psij' / 'work'
+
+    def __init__(self, launcher_log_file: Optional[Path] = None,
+                 work_directory: Optional[Path] = None) -> None:
         """
         Initializes a configuration object.
 
-        :param launcher_log_file: If specified, log messages from launcher scripts (including
+        Parameters
+        ----------
+        launcher_log_file
+            If specified, log messages from launcher scripts (including
             output from pre- and post- launch scripts) will be directed to this file.
+        work_directory
+            A directory where submit scripts and auxiliary job files will be generated. In a,
+            cluster this directory needs to point to a directory on a shared filesystem. This is so
+            that the exit code file, likely written on a service node, can be accessed by PSI/J,
+            likely running on a head node.
         """
         self.launcher_log_file = launcher_log_file
+        if work_directory:
+            self.work_directory = work_directory
+        else:
+            self.work_directory = JobExecutorConfig.DEFAULT_WORK_DIRECTORY
 
 
 JobExecutorConfig.DEFAULT = JobExecutorConfig()

--- a/src/psij/launchers/script_based_launcher.py
+++ b/src/psij/launchers/script_based_launcher.py
@@ -98,6 +98,7 @@ class ScriptBasedLauncher(Launcher):
 
     def _deploy_file(self, path: Path) -> None:
         dst_dir = self.config.work_directory
+        dst_dir.mkdir(parents=True, exist_ok=True)
         dst_path = dst_dir / path.name
         if dst_path.exists():
             return

--- a/src/psij/launchers/scripts/launcher_lib.sh
+++ b/src/psij/launchers/scripts/launcher_lib.sh
@@ -1,7 +1,3 @@
-#!/bin/bash
-
-set -e
-
 _PSI_J_JOB_ID="$1"
 _PSI_J_LOG_FILE="$2"
 _PSI_J_PRE_LAUNCH="$3"

--- a/src/psij/launchers/scripts/launcher_lib.sh
+++ b/src/psij/launchers/scripts/launcher_lib.sh
@@ -1,3 +1,5 @@
+set -e
+
 _PSI_J_JOB_ID="$1"
 _PSI_J_LOG_FILE="$2"
 _PSI_J_PRE_LAUNCH="$3"

--- a/src/psij/launchers/scripts/mpi_launch.sh
+++ b/src/psij/launchers/scripts/mpi_launch.sh
@@ -1,4 +1,6 @@
-# <lib.sh>
+#!/bin/bash
+
+source $(dirname "$0")/launcher_lib.sh
 
 _PSI_J_PROCESS_COUNT="$1"
 shift

--- a/src/psij/launchers/scripts/multi_launch.sh
+++ b/src/psij/launchers/scripts/multi_launch.sh
@@ -1,4 +1,6 @@
-# <lib.sh>
+#!/bin/bash
+
+source $(dirname "$0")/launcher_lib.sh
 
 pre_launch
 

--- a/src/psij/launchers/scripts/single_launch.sh
+++ b/src/psij/launchers/scripts/single_launch.sh
@@ -1,4 +1,6 @@
-# <lib.sh>
+#!/bin/bash
+
+source $(dirname "$0")/launcher_lib.sh
 
 pre_launch
 

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -97,7 +97,6 @@ def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool =
     env = dict(os.environ)
     env['PYTHONPATH'] = str(cwd.absolute() / 'src') + \
         (':' + env['PYTHONPATH'] if 'PYTHONPATH' in env else '')
-    subprocess.run([sys.executable, 'setup.py', 'launcher_scripts'], cwd=cwd.absolute(), check=True)
     subprocess.run(args, cwd=cwd.absolute(), env=env)
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -23,6 +23,7 @@ def _get_executor_instance(ep: ExecutorTestParams, job: Job) -> JobExecutor:
 
 def test_simple_job(execparams: ExecutorTestParams) -> None:
     job = Job(JobSpec(executable='/bin/date', launcher=execparams.launcher))
+    job.spec.attributes.set_custom_attribute('slurm.test', 'slurm.value')
     ex = _get_executor_instance(execparams, job)
     ex.submit(job)
     job.wait()

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -23,7 +23,6 @@ def _get_executor_instance(ep: ExecutorTestParams, job: Job) -> JobExecutor:
 
 def test_simple_job(execparams: ExecutorTestParams) -> None:
     job = Job(JobSpec(executable='/bin/date', launcher=execparams.launcher))
-    job.spec.attributes.set_custom_attribute('slurm.test', 'slurm.value')
     ex = _get_executor_instance(execparams, job)
     ex.submit(job)
     job.wait()


### PR DESCRIPTION
…yment to word dir as well as sourcing of lib.sh.

This addresses a number of issues that were discussed in other PRs and on the slack channel, such as ensuring that the launcher scripts are in a location accessible from compute nodes and dealing with the increasing complexity of concatenating two files through setup.py.