### PR TITLE
Testing updates

### DIFF
--- a/psij-ci-run
+++ b/psij-ci-run
@@ -20,16 +20,20 @@ failifempty() {
     fi
 }
 
+MODE="plain"
+
 while [ "$1" != "" ]; do
     case "$1" in
         --with-conda)
             failifempty "$1" "$2"
             conda activate "$2"
+            MODE="conda"
             shift 2
             ;;
         --with-venv)
             failifempty "$1" "$2"
             source "$2/bin/activate"
+            MODE="venv"
             shift 2
             ;;
         --help)
@@ -43,11 +47,16 @@ while [ "$1" != "" ]; do
     esac
 done
 
-
 if python --version 2>&1 | egrep -q 'Python 3\..*' >/dev/null 2>&1 ; then
     PYTHON="python"
 else
     PYTHON="python3"
 fi
 
-$PYTHON tests/ci_runner.py
+
+if [ "$MODE" == "plain" ]; then
+    export PYTHONPATH="$PWD/.packages:$PYTHONPATH"
+fi
+
+
+$PYTHON tests/ci_runner.py $MODE

--- a/psij-ci-run
+++ b/psij-ci-run
@@ -53,6 +53,9 @@ else
     PYTHON="python3"
 fi
 
+# Ensure latest test runner is there
+git fetch
+git checkout origin/main -- tests/ci_runner.py
 
 if [ "$MODE" == "plain" ]; then
     export PYTHONPATH="$PWD/.packages:$PYTHONPATH"

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -1,20 +1,21 @@
 #!/bin/bash
 
+set -e
+
 if pip --version 2>&1 | egrep -q 'python 3\..*' >/dev/null 2>&1 ; then
     PIP="pip"
 else
     PIP="pip3"
 fi
 
+MODE="plain"
 
 if [ "$VIRTUAL_ENV" != "" ]; then
-    VENV=1
-    NOUSER=1
+    MODE="venv"
 fi
 
 if [ "$CONDA_SHLVL" != "" ] && [ "$CONDA_SHLVL" != "0" ]; then
-    CONDA=1
-    NOUSER=1
+    MODE="conda"
 fi
 
 
@@ -31,6 +32,12 @@ echo
 echo "================================================================"
 echo "This script will install requirements for the PSI/J CI tests and"
 echo "add a cron job to run the tests once a day at some random time. "
+echo "                                                                "
+echo "Warning: if you are using a virtual environment or Conda, this  "
+echo "script will set up tests to run inside the current virtual      "
+echo "environment or Conda environment. To avoid unwanted changes to  "
+echo "an existing environment, please exit this script, create a new  "
+echo "environment, then re-run this script.                           "
 echo "================================================================"
 echo
 
@@ -51,11 +58,19 @@ done
 
 cd "$MYPATH"
 
+echo -n "Installing dependencies..."
 
-if [ "$NOUSER" == "1" ]; then
-    $PIP install -r requirements-dev.txt
+if [ "$MODE" != "plain" ]; then
+    OUT=`$PIP install -r requirements-tests.txt 2>&1`
 else
-    $PIP install --user -r requirements-dev.txt
+    OUT=`$PIP install --target .packages --upgrade -r requirements-tests.txt 2>&1`
+fi
+
+if [ "$?" != "0" ]; then
+    echo "FAILED"
+    echo $OUT
+else
+    echo "Done"
 fi
 
 
@@ -78,10 +93,11 @@ if crontab -l 2>/dev/null | grep "psij-ci-run" >/dev/null && [ "$FORCE" != "1" ]
     exit 2
 else
     LINE="$MINUTE $HOUR * * * cd \"$MYPATH\" && ./psij-ci-run"
-    if [ "$VENV" == "1" ]; then
+    
+    if [ "$MODE" == "venv" ]; then
         LINE="$LINE --with-venv \"$VIRTUAL_ENV\""
     fi
-    if [ "$CONDA" == "1" ]; then
+    if [ "$MODE" == "conda" ]; then
         LINE="$LINE --with-conda \"$CONDA_DEFAULT_ENV\""
     fi
     LINE="$LINE >> $MYPATH/testing.log 2>&1"

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 if pip --version 2>&1 | egrep -q 'python 3\..*' >/dev/null 2>&1 ; then
     PIP="pip"
 else
@@ -69,6 +67,7 @@ fi
 if [ "$?" != "0" ]; then
     echo "FAILED"
     echo $OUT
+    exit 2
 else
     echo "Done"
 fi

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+-r requirements-connector-saga.txt

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -49,12 +49,14 @@ def read_conf(fname: str) -> Dict[str, str]:
             line = read_line(f)
     return conf
 
+
 def run(*args: str, cwd: Optional[str] = None) -> None:
-    p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False, cwd=cwd, 
-                       text=True)
+    p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False,
+                       cwd=cwd, text=True)
     if p.returncode != 0:
         print(p.stdout)
         raise subprocess.CalledProcessError(p.returncode, args, output=p.stdout)
+
 
 def get_conf(conf: Dict[str, str], name: str) -> str:
     if name not in conf:

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -66,7 +66,7 @@ def get_core_pr_branches(conf: Dict[str, str]) -> List[str]:
     repo = get_conf(conf, 'repository')
     resp = requests.get('%s/repos/%s/pulls?state=open&per_page=100' % (GITHUB_API_ROOT, repo))
     resp.raise_for_status()
-    branches = []
+    branches = ['main']
     for pr in resp.json():
         if pr['head']['repo']['full_name'] == repo:
             branches.append(pr['head']['ref'])

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -15,6 +15,7 @@ import requests
 STABLE_BRANCHES = ['main']
 FAKE_BRANCHES = ['main', 'feature_1', 'feature_x']
 GITHUB_API_ROOT = 'https://api.github.com'
+MODE = 'plain'
 
 
 def read_line(f: TextIO) -> Optional[str]:
@@ -48,6 +49,12 @@ def read_conf(fname: str) -> Dict[str, str]:
             line = read_line(f)
     return conf
 
+def run(*args: str, cwd: Optional[str] = None) -> None:
+    p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False, cwd=cwd, 
+                       text=True)
+    if p.returncode != 0:
+        print(p.stdout)
+        raise subprocess.CalledProcessError(p.returncode, args, output=p.stdout)
 
 def get_conf(conf: Dict[str, str], name: str) -> str:
     if name not in conf:
@@ -68,12 +75,28 @@ def get_core_pr_branches(conf: Dict[str, str]) -> List[str]:
 
 def do_clone(conf: Dict[str, str], dir: Path) -> None:
     repo = get_conf(conf, 'repository')
-    subprocess.run(['git', 'clone', 'https://github.com/%s.git' % repo, 'code'], check=True,
-                   cwd=str(dir))
+    run('git', 'clone', 'https://github.com/%s.git' % repo, 'code', cwd=str(dir))
 
 
 def checkout(branch: str, dir: Path) -> None:
-    subprocess.run(['git', 'checkout', branch], check=True, cwd=str(dir / 'code'))
+    run('git', 'checkout', branch, cwd=str(dir / 'code'))
+
+
+def get_pip() -> str:
+    if sys.executable[-1] == '3':
+        return 'pip3'
+    else:
+        return 'pip'
+
+
+def install_deps(branch: str, dir: Path) -> None:
+    reqpath = dir / 'code' / 'requirements-tests.txt'
+    if not reqpath.exists():
+        return
+    if MODE == 'plain':
+        run(get_pip(), 'install', '--target', '.packages', '--upgrade', '-r', str(reqpath))
+    else:
+        run(get_pip(), 'install', '--upgrade', '-r', str(reqpath))
 
 
 def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool = True,
@@ -117,6 +140,7 @@ def run_tests(conf: Dict[str, str], site_ids: List[str], branches: List[str], cl
             for branch in branches:
                 if clone:
                     checkout(branch, tmpp)
+                    install_deps(branch, tmpp)
                 with info('Testing branch "%s"' % branch):
                     run_branch_tests(conf, tmpp, run_id, clone, site_id, branch)
 
@@ -134,6 +158,8 @@ def info(msg: str) -> Generator[bool, None, None]:
 
 
 if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        MODE = sys.argv[1]
     with info('Reading configuration'):
         conf = read_conf('testing.conf')
     scope = get_conf(conf, 'scope')


### PR DESCRIPTION
This PR contains a bunch of more-or-less minor updates to testing:
- always check out a current ci-runner from main
- move non-venv non-conda dep installs from --user to .packages inside the testing setup dir
- install/upgrade dependencies on every branch that is tested
- add a requirements-tests.txt, which installs only dependencies needed for testing