### PR TITLE
Invoke launcher with actual deployed path rather than the source path.

### DIFF
--- a/src/psij/launchers/script_based_launcher.py
+++ b/src/psij/launchers/script_based_launcher.py
@@ -116,7 +116,7 @@ class ScriptBasedLauncher(Launcher):
             return dst_path
         except FileExistsError:
             # thrown in Windows if the path already exists, which is fine if the destination is a
-            # file; we were recing another process
+            # file; we were racing another process
             if dst_path.is_dir():
                 raise
             else:


### PR DESCRIPTION
On non-clusters, the existing code works. On clusters, when tests are
run from a non-shared FS, the path inside the source to the launchers
is not visible from CNs, so things fail.