### PR TITLE
Alternative test run method to cron

### DIFF
--- a/psij-ci-run
+++ b/psij-ci-run
@@ -3,12 +3,13 @@
 usage() {
     cat <<EOF
 Usage: ./psij-ci-run [--help] [--with-conda <conda_env_name>] 
-            [--with-venv <venv_name>]
+            [--with-venv <venv_name>] [--repeat]
     --help          Displays this message
     --with-conda    Specifies a conda environment to activate before running 
                     the tests
     --with-venv     Specifies a virtualenv environment to load before running
                     the tests
+    --repeat        If specified, run tests every 24 hours in a loop.
 EOF
 }
 
@@ -21,6 +22,7 @@ failifempty() {
 }
 
 MODE="plain"
+REPEAT=0
 
 while [ "$1" != "" ]; do
     case "$1" in
@@ -39,6 +41,10 @@ while [ "$1" != "" ]; do
         --help)
             usage
             exit 0
+            ;;
+        --repeat)
+            REPEAT=1
+            shift
             ;;
         *)
             echo "Unrecognized command line option: $1."
@@ -61,5 +67,15 @@ if [ "$MODE" == "plain" ]; then
     export PYTHONPATH="$PWD/.packages:$PYTHONPATH"
 fi
 
-
-$PYTHON tests/ci_runner.py $MODE
+if [ "$REPEAT" == "1" ]; then
+    CRT_TIME=`date +%s`
+    while true ; do
+        $PYTHON tests/ci_runner.py $MODE
+        CRT_TIME=$((CRT_TIME + 86400))
+        NOW=`date +%s`
+        TO_SLEEP=$((CRT_TIME - NOW))
+        sleep $TO_SLEEP
+    done
+else
+    $PYTHON tests/ci_runner.py $MODE
+fi

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -85,8 +85,6 @@ fi
 if [ "$MODE" == "conda" ]; then
     CMD="$CMD --with-conda \"$CONDA_DEFAULT_ENV\""
 fi
-CMD="$CMD >> $MYPATH/testing.log 2>&1"
-
 
 if ps aux | grep -e '^root.*cron' >/dev/null 2>&1 ; then
     # looks like some cron daemon is running

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -122,7 +122,7 @@ elif which screen >/dev/null 2>&1 ; then
     echo "It looks like there is no cron daemon running. As an            "
     echo "alternative, this script can start a GNU Screen session that    "
     echo "runs the tests once a day, using the following command:         "
-    echo ">>> $CMD"
+    echo ">>> screen -d -m $CMD"
     echo "================================================================"
     
     RESPONSE=""

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -77,35 +77,78 @@ HOUR=`echo $(($RANDOM % 24))`
 MINUTE=`echo $(($RANDOM % 60))`
 MYPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-if crontab -l 2>/dev/null | grep "psij-ci-run" >/dev/null && [ "$FORCE" != "1" ]; then
-    EXISTING=`crontab -l 2>/dev/null | grep "psij-ci-run"`
-    echo
-    echo "================================================================"
-    echo "Error: a crontab for PSI/J tests already exists: "
-    echo ">>> $EXISTING"
-    echo
-    echo "You can edit your crontab with \"crontab -e\" and remove the    "
-    echo "existing entry, then re-run this tool. If you are certain that  "
-    echo "you want to install multiple entries, you can re-run this script"
-    echo "with the \"-f\" flag.                                           "
-    echo "================================================================"
-    exit 2
-else
-    LINE="$MINUTE $HOUR * * * cd \"$MYPATH\" && ./psij-ci-run"
+CMD="./psij-ci-run"
+
+if [ "$MODE" == "venv" ]; then
+    CMD="$CMD --with-venv \"$VIRTUAL_ENV\""
+fi
+if [ "$MODE" == "conda" ]; then
+    CMD="$CMD --with-conda \"$CONDA_DEFAULT_ENV\""
+fi
+CMD="$CMD >> $MYPATH/testing.log 2>&1"
+
+
+if ps aux | grep -e '^root.*cron' >/dev/null 2>&1 ; then
+    # looks like some cron daemon is running
+
+    if crontab -l 2>/dev/null | grep "psij-ci-run" >/dev/null && [ "$FORCE" != "1" ]; then
+        EXISTING=`crontab -l 2>/dev/null | grep "psij-ci-run"`
+        echo
+        echo "================================================================"
+        echo "Error: a crontab for PSI/J tests already exists:                "
+        echo ">>> $EXISTING"
+        echo
+        echo "You can edit your crontab with \"crontab -e\" and remove the    "
+        echo "existing entry, then re-run this tool. If you are certain that  "
+        echo "you want to install multiple entries, you can re-run this script"
+        echo "with the \"-f\" flag.                                           "
+        echo "================================================================"
+        exit 2
+    else
+        CMD="$CMD >> $MYPATH/testing.log 2>&1"
+        LINE="$MINUTE $HOUR * * * cd \"$MYPATH\" && $CMD"
     
-    if [ "$MODE" == "venv" ]; then
-        LINE="$LINE --with-venv \"$VIRTUAL_ENV\""
+        echo
+        echo "================================================================"
+        echo "The following line will be installed in your crontab:"
+        echo "$LINE"
+        { crontab -l & echo "$LINE"; } | crontab -
+        echo "Setup complete. If you have not already done so, please take    "
+        echo "some time to customize testing.conf.                            "
+        echo "================================================================"
     fi
-    if [ "$MODE" == "conda" ]; then
-        LINE="$LINE --with-conda \"$CONDA_DEFAULT_ENV\""
-    fi
-    LINE="$LINE >> $MYPATH/testing.log 2>&1"
+elif which screen >/dev/null 2>&1 ; then
+    CMD="$CMD --repeat >> $MYPATH/testing.log 2>&1"
     echo
     echo "================================================================"
-    echo "The following line will be installed in your crontab:"
-    echo "$LINE"
-    { crontab -l & echo "$LINE"; } | crontab -
-    echo "Setup complete. If you have not already done so, please take    "
-    echo "some time to customize testing.conf.                            "
+    echo "It looks like there is no cron daemon running. As an            "
+    echo "alternative, this script can start a GNU Screen session that    "
+    echo "runs the tests once a day, using the following command:         "
+    echo ">>> $CMD"
+    echo "================================================================"
+    
+    RESPONSE=""
+
+    while [ "$RESPONSE" != "Y" ] && [ "$RESPONSE" != "X" ]; do
+
+        echo -n "Would you like to start a (S)creen session or E(x)it? "
+        read -n1 RESPONSE
+        echo
+        RESPONSE=${RESPONSE^}
+    
+        if [ "$RESPONSE" == "X" ]; then
+            echo "Operation canceled"
+            exit 1
+        fi
+    done
+
+    screen -d -m $CMD
+else
+    CMD="$CMD --repeat >> $MYPATH/testing.log 2>&1"
+    echo
+    echo "================================================================"
+    echo "It looks like there is no cron daemon running. Please run the   "
+    echo "following command in the background:                            "
+    echo ">>> $CMD"
     echo "================================================================"
 fi

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -129,7 +129,7 @@ elif which screen >/dev/null 2>&1 ; then
     
     RESPONSE=""
 
-    while [ "$RESPONSE" != "Y" ] && [ "$RESPONSE" != "X" ]; do
+    while [ "$RESPONSE" != "S" ] && [ "$RESPONSE" != "X" ]; do
 
         echo -n "Would you like to start a (S)creen session or E(x)it? "
         read -n1 RESPONSE

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -122,7 +122,7 @@ elif which screen >/dev/null 2>&1 ; then
     echo "It looks like there is no cron daemon running. As an            "
     echo "alternative, this script can start a GNU Screen session that    "
     echo "runs the tests once a day, using the following command:         "
-    echo ">>> screen -d -m $CMD"
+    echo ">>> screen -d -m bash -c \"$CMD\""
     echo "================================================================"
     
     RESPONSE=""
@@ -140,7 +140,7 @@ elif which screen >/dev/null 2>&1 ; then
         fi
     done
 
-    screen -d -m $CMD
+    screen -d -m bash -c "$CMD"
 else
     CMD="$CMD --repeat >> $MYPATH/testing.log 2>&1"
     echo


### PR DESCRIPTION
Not all systems actually start the cron daemon, so cron is really not a given. This PR provides a gnu screen based alternative to running the tests, and, as a fallback, instructions to run the test loop manually.