### PR TITLE
On orthus.nic.uoregon.edu redirect tests fail because the temporary d…

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -38,6 +38,7 @@ def test_simple_job_redirect(execparams: ExecutorTestParams) -> None:
         job.wait()
         f = outp.open("r")
         contents = f.read()
+        f.close()
         assert contents == '_x_'
 
 


### PR DESCRIPTION
…irectory where the output is redirected cannot be removed at the end of the test. I can't reproduce the problem, but I suspect the above may have something to do with it.