### PR TITLE
Switch back to official pystache

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,23 +1,14 @@
-# Runtime dependencies
-filelock
-psutil
-# pystache>=0.5.4
-https://github.com/ExaWorks/pystache/archive/refs/tags/v0.5.5-ew.tar.gz
+-r requirements.txt
+-r requirements-docs.txt
 
-# Docs
-six
-Sphinx
-sphinx_rtd_theme
-sphinx-tabs
-# sphinx-autodoc-typehints
+# Executors
+-r requirements-connector-saga.txt
+-r requirements-connector-radical.txt
 
-# Testing
+# Testing / QA
 mypy >=0.790
 pytest
 flake8
 autopep8
 types-requests
 
-# For SAGA executor
-radical.saga
-radical.utils

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,15 @@
+# Everything that is required to build the docs
 -r requirements.txt
+
+# Executors
+-r requirements-connector-saga.txt
 -r requirements-connector-radical.txt
+
+
+# Docs
+six
+Sphinx
+sphinx_rtd_theme
+sphinx-tabs
+# sphinx-autodoc-typehints
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 filelock
 psutil
-# pystache>=0.5.4
-https://github.com/ExaWorks/pystache/archive/refs/tags/v0.5.5-ew.tar.gz
+pystache>=0.6.0
+


### PR DESCRIPTION
The PyPI pystache packages has been taken over by another developer who is now actively maintaining it. This version is also now compatible with newer versions of Python (3.6+).

Additionally, this PR reorganizes the requirements files a bit to make them consistent and reduce duplication.