### PR TITLE
Increase python version requirement from >=3.6 to >=3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     runs-on: ubuntu-latest
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ if __name__ == '__main__':
 
         install_requires=[
         ],
-        python_requires='>=3.6'
+        python_requires='>=3.7'
     )


### PR DESCRIPTION
Fixes #123.

Python 3.6 has reached its EOL.