### PR TITLE
Fix exploding pythonpath

### DIFF
--- a/psij-ci-run
+++ b/psij-ci-run
@@ -58,7 +58,6 @@ fi
 git fetch
 git checkout origin/main -- tests/ci_runner.py
 
-export PYTHONPATH="$PWD/.packages:$PYTHONPATH"
 
 if [ "$REPEAT" == "1" ]; then
     CRT_TIME=`date +%s`

--- a/psij-ci-run
+++ b/psij-ci-run
@@ -55,7 +55,7 @@ else
 fi
 
 # Ensure latest test runner is there
-git fetch
+git fetch https://github.com/ExaWorks/psi-j-python.git
 git checkout origin/main -- tests/ci_runner.py
 
 

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -118,8 +118,15 @@ def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool =
         args.append(fake_branch_name)
     for opt in ['maintainer_email', 'executors', 'server_url', 'key', 'max_age',
                 'custom_attributes']:
-        args.append('--' + opt.replace('_', '-'))
-        args.append(get_conf(conf, opt))
+        try:
+            val = get_conf(conf, opt)
+            args.append('--' + opt.replace('_', '-'))
+            args.append(val)
+        except KeyError:
+            # sometimes options get added; when they do, they could prevent
+            # old test cycles from working, if their configs don't contain
+            # the new options
+            pass
     cwd = (dir / 'code') if clone else Path('.')
     env = dict(os.environ)
     env['PYTHONPATH'] = str(Path('.').resolve() / '.packages') \

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -122,9 +122,10 @@ def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool =
         args.append(get_conf(conf, opt))
     cwd = (dir / 'code') if clone else Path('.')
     env = dict(os.environ)
-    env['PYTHONPATH'] = str(cwd.absolute() / 'src') + \
-        (':' + env['PYTHONPATH'] if 'PYTHONPATH' in env else '')
-    subprocess.run(args, cwd=cwd.absolute(), env=env)
+    env['PYTHONPATH'] = str(Path('.').resolve() / '.packages') \
+        + ':' + str(cwd.resolve() / 'src') \
+        + (':' + env['PYTHONPATH'] if 'PYTHONPATH' in env else '')
+    subprocess.run(args, cwd=cwd.resolve(), env=env)
 
 
 def get_run_id() -> str:


### PR DESCRIPTION
With AT as a scheduler for running tests, psij-ci-run would, before every scheduling command, do `export PYTHONPATH=.packages:$PYTHONPATH`. Then AT would pick that up and invoke psij-ci-run with the updated `PYTHONPATH` in the next iteration. In time, `PYTHONPATH` would become larger than the OS limits.

This was fine until tests started requiring the addition of a path to PYTHONPATH, which, done in branch_test_wrapper.sh (without set -e) would silently fail.

This PR also adds the following to the ci tools:
- selectively pass config options in ci-runner; this is necessary if new pass-through attributes are added to ci-runner, but without a corresponding update of testing.conf, a scenario which can very well occur with automated tests
- use https:// to update ci-runner from psij-ci-run; without doing so, and depending how the code was checked out when the tests were set up as well as what environment variables are and are not available when psij-ci-run is invoked, the `git fetch` step could fail with authentication errors.

After merging this PR, it is quite likely that many test deployments will need updating:
- all methods: `git pull`
- AT: `git pull` followed by `atrm` the current job and re-running of `psij-ci-setup`

