### PR TITLE
On some OSX installations, bash has v3.2.x. That version does not rec…

### DIFF
--- a/src/psij/launchers/scripts/launcher_lib.sh
+++ b/src/psij/launchers/scripts/launcher_lib.sh
@@ -16,7 +16,7 @@ fi
 
 ts() {
     while read LINE; do
-        TZ=UTC printf -v TS "%(%F %T)T" -1
+        TZ=UTC TS=`date '+%Y-%m-%d %H:%M:%S'`
         echo "$TS $_PSI_J_JOB_ID $LINE"
     done
 }


### PR DESCRIPTION
…ognize the timestamp format for printf.

So this PR changes that part to use `date` with (hopefully) a widely accepted format string.