### PR TITLE
Export type annotations (PEP 561)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ if __name__ == '__main__':
             '': ['README.md', 'LICENSE'],
             'psij.launchers.scripts': [ '*.sh' ],
             'psij.executors.batch.test': [ 'qdel', 'qstat', 'qsub', 'qrun' ],
-            'psij.executors.batch': [ '**/*.mustache' ]
+            'psij.executors.batch': [ '**/*.mustache' ],
+            'psij': ["py.typed"]
         },
 
 


### PR DESCRIPTION
This allows user packages (in my case, the parsl provider) to be checked against type annotations of psij code, when mypy is used when developing those user packages.

This is in contrast to the existing use of mypy and type annotations in psij, which checks that psij is internally self-consistent.