### PR TITLE
Increase mypy lower bound as 0.790 breaks

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 -r requirements-connector-radical.txt
 
 # Testing / QA
-mypy >=0.790
+mypy >=0.931
 pytest >= 6.2.0
 flake8
 autopep8


### PR DESCRIPTION
In other projects I've found mypy behaviour changing fast enough
that I've ended up pinning a version explicitly.