### PR TITLE
Ci updates

### DIFF
--- a/README-testing.md
+++ b/README-testing.md
@@ -16,24 +16,28 @@ How to run tests
 There are a number of ways to run tests. Invoking `pytest` directly,
 running the integration tests and through `cron` (or a similar tool).
 
-Setting up a Cron testing job
-=============================
-
-Note: If you need to set up an environment module (such as 
-`module load python/cpython-x.y.z`) or something similar, please add the 
-relevant commands to `psij-ci-load`.
-
+Setting up an automated testing job
+===================================
 
 This is the preferred way of running the tests since it allows the PSI/J
 team to keep a constant eye on the state of the library on various
-resources. To set up the Cron job, you can either use the provided
-script:
+resources. To set up the Cron job (or an alternative method), you can either 
+use the provided setup script:
 
 ```bash
     ./psij-ci-setup
 ```
 
 or manually set up the CI runner with Cron or your favorite scheduler.
+
+Note: If you need to set up an environment module (such as 
+`module load python/cpython-x.y.z`) or something similar, such as
+loading a conda or virtual environment, please add the relevant commands to
+`psij-ci-load`, which is sourced before tests are run by `psij-ci-run`. If the
+setup script is run under a venv or Conda, it will attempt to detect this and 
+ask whether the relevant environment activation commands should be added to 
+`psij-ci-load`. However, not all circumstances can be reliably detected and 
+you may need to manually edit `psij-ci-load`.
 
 Testing with the CI runner
 ==========================

--- a/psij-ci-load
+++ b/psij-ci-load
@@ -1,3 +1,4 @@
 # This file can be used to set up an environment before tests are run.
 # For example, one can issue relevant "module load" commands here. The
 # file will then be sourced by both psij-ci-setup and psij-ci-run.
+

--- a/psij-ci-run
+++ b/psij-ci-run
@@ -2,13 +2,8 @@
 
 usage() {
     cat <<EOF
-Usage: ./psij-ci-run [--help] [--with-conda <conda_env_name>] 
-            [--with-venv <venv_name>] [--repeat]
+Usage: ./psij-ci-run [--help] [--repeat]
     --help          Displays this message
-    --with-conda    Specifies a conda environment to activate before running 
-                    the tests
-    --with-venv     Specifies a virtualenv environment to load before running
-                    the tests
     --repeat        If specified, run tests every 24 hours in a loop.
 EOF
 }

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source psij-ci-load
-
 if pip --version 2>&1 | egrep -q 'python 3\..*' >/dev/null 2>&1 ; then
     PIP="pip"
 else

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -45,6 +45,74 @@ cron_install() {
     echo "$LINE"
     echo "================================================================"
     { crontab -l & echo "$LINE"; } | crontab -
+
+    if [ "$VIRTUAL_ENV" != "" ]; then
+        maybe_add_to_load "virtual" "$VIRTUAL_ENV" \
+            "source \"$VIRTUAL_ENV/bin/activate\"" "/bin/activate"
+    fi
+    if [ "$CONDA_SHLVL" != "" ] && [ "$CONDA_SHLVL" != "0" ]; then
+        maybe_add_to_load "conda" "$CONDA_DEFAULT_ENV" \
+            "activate \"$CONDA_DEFAULT_ENV\"" "activate "
+    fi
+}
+
+maybe_add_to_load() {
+    LABEL="$1"
+    ID="$2"
+    TO_ADD="$3"
+    TO_CHECK="$4"
+    # check if psij-ci-load contains TO_CHECK, but not the actual TO_ADD.
+    # the idea being that we want /to/add/TO_CHECK to be fine if already added,
+    # but /something/else/TO_CHECK to trigger an error
+
+    CONFLICTING=`cat ./psij-ci-load | sed 's/#[^!].*$//' | grep "$TO_CHECK" 2>/dev/null`
+    C_COUNT=`echo -n "$CONFLICTING" | grep -c ""`
+    if [ "$C_COUNT" == "0" ]; then
+        # continue to asking
+        :
+    elif [ "$C_COUNT" == "1" ]; then
+        OUT=`echo "$CONFLICTING" | grep "$TO_ADD"`
+        if echo "$CONFLICTING" | grep "$TO_ADD" >/dev/null; then
+            # we're good, the line is already there
+            return 0
+        else
+            echo
+            echo "================================================================"
+            echo "Warning!                                                        "
+            echo "You appear to be running under a $LABEL environment:            "
+            echo "    $ID                                                         "
+            echo "Your psij-ci-load contains a different $LABEL environment:      "
+            echo "    $CONFLICTING                                                "
+            echo "Please manually edit psij-ci-load and resolve the conflict. If  "
+            echo "you are setting up tests under multiple environments, please do "
+            echo "so in a different directory for each environment.               "
+            echo "================================================================"
+            echo
+            exit 1
+        fi
+    fi
+
+    echo
+    echo "================================================================"
+    echo "You appear to be running under a $LABEL environment.            "
+    echo "Would you like for the following to be automatically added to   "
+    echo "psij-ci-load?                                                   "
+    echo "    $TO_ADD                                                     "
+    echo
+    while [ "$RESPONSE" != "A" ] && [ "$RESPONSE" != "X" ]; do
+
+        echo -n "(A)dd or E(x)it? "
+        read -n1 RESPONSE
+        echo
+        RESPONSE=${RESPONSE^}
+
+        if [ "$RESPONSE" == "X" ]; then
+            exit 0
+        elif [ "$RESPONSE" == "A" ]; then
+            echo "$TO_ADD" >> ./psij-ci-load
+            return 0
+        fi
+    done
 }
 
 at_check() {
@@ -175,12 +243,6 @@ echo "                                                                "
 echo "If you need to set up a special environment, such as loading an "
 echo "environment module please exit this script and add the relevant "
 echo "commands to psij-ci-load.                                       "
-echo "                                                                "
-echo "Warning: if you are using a virtual environment or Conda, this  "
-echo "script will set up tests to run inside the current virtual      "
-echo "environment or Conda environment. To avoid unwanted changes to  "
-echo "an existing environment, please exit this script, create a new  "
-echo "environment, then re-run this script.                           "
 echo "================================================================"
 echo
 


### PR DESCRIPTION
This fixes #148, and #149. It also updates the testing readme and removes the automatic loading of `psij-ci-load` by `psij-ci-setup` (but not `psij-ci-run`).