### PR TITLE
handle errors in status loop of batch schedulers

### DIFF
--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -566,6 +566,11 @@ class _QueuePollThread(Thread):
         except subprocess.CalledProcessError as ex:
             out = ex.output
             exit_code = ex.returncode
+        except Exception as ex:
+            self._handle_poll_error(True,
+                                    ex,
+                                    f'Failed to poll for job status: {traceback.format_exc()}')
+            return
         else:
             exit_code = 0
             self._poll_error_count = 0
@@ -573,7 +578,7 @@ class _QueuePollThread(Thread):
         try:
             status_map = self.executor.parse_status_output(exit_code, out)
         except Exception as ex:
-            self._handle_poll_error(True,
+            self._handle_poll_error(False,
                                     ex,
                                     f'Failed to poll for job status: {traceback.format_exc()}')
             return


### PR DESCRIPTION
Fail jobs if `get_status_command` did not yield any usable output, at all, either because the executor was not able to form the correct command or because psij was not able to run it.  In these cases  re-trying would be useless.

This PR though enables a retry if the command did, in fact, yield some output, even if that output may be faulty or incomplete.  We assume here that this could be caused by an intermittent error of the batch system (node overloaded, batch system unresponsive, etc.), and that a retry has a chance of success.

This PR fixes #144.