### PR TITLE
Docs: API guide

### DIFF
--- a/docs/programming.rst
+++ b/docs/programming.rst
@@ -15,12 +15,15 @@ configuration options, to the extent possible.
 
 .. autoclass:: psij.Job
     :members:
+    :noindex:
 
 .. autoclass:: psij.JobStatus
     :members:
+    :noindex:
 
 .. autoclass:: psij.JobState
     :members:
+    :noindex:
 
 Job modifiers
 ^^^^^^^^^^^^^
@@ -36,12 +39,15 @@ scheduling policies.
 
 .. autoclass:: psij.JobSpec
     :members:
+    :noindex:
 
 .. autoclass:: psij.ResourceSpec
     :members:
+    :noindex:
 
 .. autoclass:: psij.JobAttributes
     :members:
+    :noindex:
 
 
 .. _executors:
@@ -87,6 +93,7 @@ The ``psij.JobExecutor`` class is abstract, but offers concrete static methods
 for registering, fetching, and listing subclasses of itself.
 
 .. autoclass:: psij.job_executor.JobExecutor
+    :noindex:
 
 The concrete executor implementations provided by this version of PSI/J Python
 are:
@@ -95,36 +102,43 @@ Cobalt
 ^^^^^^
 
 .. autoclass:: psij.executors.batch.cobalt.CobaltJobExecutor
+    :noindex:
 
 Flux
 ^^^^
 
 .. autoclass:: psij.executors.flux.FluxJobExecutor
+    :noindex:
 
 LSF
 ^^^
 
 .. autoclass:: psij.executors.batch.lsf.LsfJobExecutor
+    :noindex:
 
 PBS
 ^^^
 
 .. autoclass:: psij.executors.batch.pbspro.PBSProJobExecutor
+    :noindex:
 
 Slurm
 ^^^^^
 
 .. autoclass:: psij.executors.batch.slurm.SlurmJobExecutor
+    :noindex:
 
 Local
 ^^^^^
 
 .. autoclass:: psij.executors.local.LocalJobExecutor
+    :noindex:
 
 Radical Pilot
 ^^^^^^^^^^^^^
 
 .. autoclass:: psij.executors.rp.RPJobExecutor
+    :noindex:
 
 .. _launchers:
 
@@ -153,6 +167,7 @@ Like the executor, the ``Launcher`` base class is abstract, but offers
 concrete static methods for registering and fetching subclasses of itself.
 
 .. autoclass:: psij.Launcher
+    :noindex:
 
 The PSI/J Python library comes with a core set of launchers, which are:
 
@@ -161,42 +176,49 @@ aprun
 
 .. autoclass:: psij.launchers.aprun.AprunLauncher
     :members:
+    :noindex:
 
 jsrun
 ^^^^^
 
 .. autoclass:: psij.launchers.jsrun.JsrunLauncher
     :members:
+    :noindex:
 
 srun
 ^^^^
 
 .. autoclass:: psij.launchers.srun.SrunLauncher
     :members:
+    :noindex:
 
 mpirun
 ^^^^^^
 
 .. autoclass:: psij.launchers.mpirun.MPILauncher
     :members:
+    :noindex:
 
 single
 ^^^^^^
 
 .. autoclass:: psij.launchers.single.SingleLauncher
     :members:
+    :noindex:
 
 multiple
 ^^^^^^^^
 
 .. autoclass:: psij.launchers.multiple.MultipleLauncher
     :members:
+    :noindex:
 
 Other Package Contents
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: psij.exceptions
     :members:
+    :noindex:
 
 
 API Reference

--- a/docs/programming.rst
+++ b/docs/programming.rst
@@ -1,50 +1,47 @@
 The PSI/J API
 =============
 
+The most important classes in this library are ``Job`` and ``JobExecutor``,
+followed by ``Launcher``.
 
-The PSI/J core
-~~~~~~~~~~~~~~
+The Job class and its modifiers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The core API contains the central components of PSI/J. The core API
-classes are independent of executor implementations. User code should
-only program against the core API. The major classes are:
+The Job-related classes listed in this section (``Job``, ``JobSpec``,
+``ResourceSpec``, and ``JobAttributes``) are independent of
+executor implementations. The authors strongly recommend that users
+program against these classes, rather than adding executor-specific
+configuration options, to the extent possible.
 
-:class:`~psij.job.Job`
-    Represents a scheduler job, including all its details and state.
+.. autoclass:: psij.Job
+    :members:
 
-:class:`~psij.job_spec.JobSpec`
-    Contains the static description of a job at a level that would be
-    supported by the POSIX interface, such as path to the executable,
-    arguments, etc.
+.. autoclass:: psij.JobStatus
+    :members:
 
-:class:`~psij.resource_spec.ResourceSpec`
+.. autoclass:: psij.JobState
+    :members:
 
-    Describes resource requirements for the job, such as number of nodes,
-    etc.
+Job modifiers
+^^^^^^^^^^^^^
 
-:class:`~psij.job_attributes.JobAttributes`
-    Contains information about a job that goes beyond POSIX and is
-    specific to batch schedulers, such as a queue name, walltime limit,
-    etc.
+There can be a lot of configuration information that goes into each
+resource manager job. Its walltime, partition/queue, the number of nodes
+it needs, what kind of nodes, what quality of service the job requires, and
+so on.
 
-:class:`~psij.job_state.JobState`
-    An enumeration containing all possible states of a job.
+PSI/J splits those three attributes into three groups: one for generic
+POSIX information, one for resource information, and one for resource manager
+scheduling policies.
 
-:class:`~psij.job_status.JobStatus`
-    An object that represents the transition of a job to a new
-    :class:`~psij.job_state.JobState`.
+.. autoclass:: psij.JobSpec
+    :members:
 
-:class:`~psij.job_executor.JobExecutor`
-    The base class for a concrete method of executing a job, such as
-    Slurm, or PBS.
+.. autoclass:: psij.ResourceSpec
+    :members:
 
-:class:`~psij.launcher.Launcher`
-    A base class representing a method of actually launching a job once
-    resources are allocated for it, such as `mpirun`, `srun`, etc.
-
-:py:mod:`~psij.exceptions`
-    A module that contanins exception classes for the PSI/J Python
-    library.
+.. autoclass:: psij.JobAttributes
+    :members:
 
 
 .. _executors:
@@ -55,9 +52,26 @@ Executors
 Executors are concrete implementations of mechanisms that execute jobs.
 To get an instance of a specific executor, call
 :meth:`JobExecutor.get_instance(name) <psij.job_executor.JobExecutor.get_instance>`,
-with ``name`` being one of the installed executor names. Executors can be
+with ``name`` being one of the installed executor names. Alternatively, directly
+instantiate the executor, e.g.
+
+.. code-block:: python
+
+    from psij.executors.flux import FluxJobExecutor
+
+    ex = FluxJobExecutor()
+
+Rather than
+
+.. code-block:: python
+
+    import psij
+
+    ex = psij.JobExecutor.get_instance('flux')
+
+Executors can be
 installed from multiple sources, so the precise list of executors
-avaiable to a specific installation of the PSI/J Python library can vary.
+available to a specific installation of the PSI/J Python library can vary.
 In order to get a list of available executors, you can run, in a
 terminal:
 
@@ -66,34 +80,54 @@ terminal:
     $ python -m psij plugins
 
 
-The executor implementations provided by this version of PSI/J Python
+JobExecutor Base Class
+^^^^^^^^^^^^^^^^^^^^^^
+
+The ``psij.JobExecutor`` class is abstract, but offers concrete static methods
+for registering, fetching, and listing subclasses of itself.
+
+.. autoclass:: psij.job_executor.JobExecutor
+
+The concrete executor implementations provided by this version of PSI/J Python
 are:
 
-:class:`cobalt <psij.executors.batch.cobalt.CobaltJobExecutor>`
-    A job executor that can interact with the
-    `Cobalt HPC Job Scheduler <https://xgitlab.cels.anl.gov/aig-public/cobalt>`_,
-    which is used by `Argonne's <www.anl.gov>`_ `ALCF <www.alcf.anl.gov>`_ systems.
+Cobalt
+^^^^^^
 
-:class:`flux <psij.executors.flux.FluxJobExecutor>`
-    Job executor for the `Flux scheduler <http://flux-framework.org/>`_.
+.. autoclass:: psij.executors.batch.cobalt.CobaltJobExecutor
 
-:class:`local <psij.executors.local.LocalJobExecutor>`
-    A job executor that runs jobs locally by forking a subprocess.
+Flux
+^^^^
 
-:class:`lsf <psij.executors.batch.lsf.LsfJobExecutor>`
-    An implementation of a job executor for the
-    `IBM Spectrum LSF workload manager <https://www.ibm.com/docs/en/spectrum-lsf>`_.
+.. autoclass:: psij.executors.flux.FluxJobExecutor
 
-:class:`rp <psij.executors.rp.RPJobExecutor>`
-    Job executor for the `RADICAL Pilot system
-    <https://radical-cybertools.github.io/radical-pilot/>`_.
+LSF
+^^^
 
-:class:`slurm <psij.executors.batch.slurm.SlurmJobExecutor>`
-    An executor for the
-    `Slurm Workload Manager <https://slurm.schedmd.com/overview.html>`_.
+.. autoclass:: psij.executors.batch.lsf.LsfJobExecutor
 
+PBS
+^^^
+
+.. autoclass:: psij.executors.batch.pbspro.PBSProJobExecutor
+
+Slurm
+^^^^^
+
+.. autoclass:: psij.executors.batch.slurm.SlurmJobExecutor
+
+Local
+^^^^^
+
+.. autoclass:: psij.executors.local.LocalJobExecutor
+
+Radical Pilot
+^^^^^^^^^^^^^
+
+.. autoclass:: psij.executors.rp.RPJobExecutor
 
 .. _launchers:
+
 
 Launchers
 ~~~~~~~~~
@@ -112,32 +146,57 @@ of launchers, you can run:
 
     $ python -m psij plugins
 
+Launcher base class
+^^^^^^^^^^^^^^^^^^^
+
+Like the executor, the ``Launcher`` base class is abstract, but offers
+concrete static methods for registering and fetching subclasses of itself.
+
+.. autoclass:: psij.Launcher
+
 The PSI/J Python library comes with a core set of launchers, which are:
 
-:class:`aprun <psij.launchers.aprun.AprunLauncher>`
-    Launches jobs using
-    `Cobalt's <https://xgitlab.cels.anl.gov/aig-public/cobalt>`_ ``aprun``.
+aprun
+^^^^^
 
-:class:`jsrun <psij.launchers.jsrun.JsrunLauncher>`
-    Starts jobs using ``jsrun`` provided by the
-    `IBM Spectrum LSF workload manager <https://www.ibm.com/docs/en/spectrum-lsf>`_.
+.. autoclass:: psij.launchers.aprun.AprunLauncher
+    :members:
 
-:class:`mpirun <psij.launchers.mpirun.MPILauncher>`
-    Launches jobs using ``mpirun``, which is a tool provided by
-    `MPI <https://www.mpi-forum.org/>`_ implementations, such as
-    `Open MPI <https://www.open-mpi.org/>`_.
+jsrun
+^^^^^
 
-:class:`multiple <psij.launchers.multiple.MultipleLauncher>`
-    Starts multiple identical instances of the same process on the same
-    machine.
+.. autoclass:: psij.launchers.jsrun.JsrunLauncher
+    :members:
 
-:class:`single <psij.launchers.single.SingleLauncher>`
-    Starts a single instance of the job executable locally. This is the
-    default launcher, which is used if nothing is explicitly specified.
+srun
+^^^^
 
-:class:`srun <psij.launchers.srun.SrunLauncher>`
-    Starts job using ``srun``, which is part of the
-    `Slurm Workload Manager <https://slurm.schedmd.com/overview.html>`_.
+.. autoclass:: psij.launchers.srun.SrunLauncher
+    :members:
+
+mpirun
+^^^^^^
+
+.. autoclass:: psij.launchers.mpirun.MPILauncher
+    :members:
+
+single
+^^^^^^
+
+.. autoclass:: psij.launchers.single.SingleLauncher
+    :members:
+
+multiple
+^^^^^^^^
+
+.. autoclass:: psij.launchers.multiple.MultipleLauncher
+    :members:
+
+Other Package Contents
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: psij.exceptions
+    :members:
 
 
 API Reference

--- a/src/psij/executors/batch/cobalt.py
+++ b/src/psij/executors/batch/cobalt.py
@@ -27,7 +27,16 @@ class CobaltExecutorConfig(BatchSchedulerExecutorConfig):
 
 
 class CobaltJobExecutor(BatchSchedulerExecutor):
-    """A :class:`~psij.JobExecutor` for the Cobalt Workload Manager."""
+    """A :class:`~psij.JobExecutor` for the Cobalt Workload Manager.
+
+    The `Cobalt HPC Job Scheduler <https://xgitlab.cels.anl.gov/aig-public/cobalt>`_,
+    is used by `Argonne's <www.anl.gov>`_ `ALCF <www.alcf.anl.gov>`_ systems.
+
+    Uses the ``qsub``, ``qstat``, and ``qdel`` commands, respectively, to submit,
+    monitor, and cancel jobs.
+
+    Creates a batch script with #COBALT directives when submitting a job.
+    """
 
     # see https://Cobalt.schedmd.com/squeue.html
     _STATE_MAP = {

--- a/src/psij/executors/batch/lsf.py
+++ b/src/psij/executors/batch/lsf.py
@@ -26,7 +26,16 @@ class LsfExecutorConfig(BatchSchedulerExecutorConfig):
 
 
 class LsfJobExecutor(BatchSchedulerExecutor):
-    """A :class:`~psij.JobExecutor` for the LSF Workload Manager."""
+    """A :class:`~psij.JobExecutor` for the LSF Workload Manager.
+
+    The `IBM Spectrum LSF workload manager <https://www.ibm.com/docs/en/spectrum-lsf>`_
+    is the system resource manager on LLNL's Sierra and Lassen, and ORNL's Summit.
+
+    Uses the 'bsub', 'bjobs', and 'bkill' commands, respectively, to submit,
+    monitor, and cancel jobs.
+
+    Creates a batch script with #BSUB directives when submitting a job.
+    """
 
     # see https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=bjobs-description
     _STATE_MAP = {

--- a/src/psij/executors/batch/pbspro.py
+++ b/src/psij/executors/batch/pbspro.py
@@ -49,7 +49,16 @@ class PBSProExecutorConfig(BatchSchedulerExecutorConfig):
 
 
 class PBSProJobExecutor(BatchSchedulerExecutor):
-    """A :class:`~psij.JobExecutor` for PBS Pro."""
+    """A :class:`~psij.JobExecutor` for PBS Pro.
+
+    `PBS Pro <https://www.altair.com/pbs-professional/>`_ is a resource manager
+    on certain machines at Argonne National Lab, among others.
+
+    Uses the 'qsub', 'qstat', and 'qdel' commands, respectively, to submit,
+    monitor, and cancel jobs.
+
+    Creates a batch script with #PBS directives when submitting a job.
+    """
 
     def __init__(self, url: Optional[str] = None, config: Optional[PBSProExecutorConfig] = None):
         """Initializes a :class:`~PBSProJobExecutor`."""

--- a/src/psij/executors/batch/slurm.py
+++ b/src/psij/executors/batch/slurm.py
@@ -17,7 +17,17 @@ class SlurmExecutorConfig(BatchSchedulerExecutorConfig):
 
 
 class SlurmJobExecutor(BatchSchedulerExecutor):
-    """A :class:`~psij.JobExecutor` for the Slurm Workload Manager."""
+    """A :class:`~psij.JobExecutor` for the Slurm Workload Manager.
+
+    The `Slurm Workload Manager <https://slurm.schedmd.com/overview.html>`_ is a
+    widely used resource manager running on machines such as
+    NERSC's Perlmutter, as well as a variety of LLNL machines.
+
+    Uses the 'sbatch', 'squeue', and 'scancel' commands, respectively, to submit,
+    monitor, and cancel jobs.
+
+    Creates a batch script with #SBATCH directives when submitting a job.
+    """
 
     # see https://slurm.schedmd.com/squeue.html
     _STATE_MAP = {

--- a/src/psij/executors/flux.py
+++ b/src/psij/executors/flux.py
@@ -31,7 +31,14 @@ import flux.job
 
 
 class FluxJobExecutor(JobExecutor):
-    """A job executor that runs jobs via Flux."""
+    """A :class:`~psij.JobExecutor` for the Flux scheduler.
+
+    The `Flux resource manager framework <http://flux-framework.org/>`_ is
+    deployed and used on a per-user basis at many sites, and is slated to become
+    the system-level resource manager at LLNL.
+
+    Uses Flux's python library/bindings to submit, monitor, and manipulate jobs.
+    """
 
     _event_map = {
         # 'submit': JobState.QUEUED,
@@ -52,7 +59,6 @@ class FluxJobExecutor(JobExecutor):
 
         :param url: Not used, but required by the spec for automatic initialization.
         :param config: The `FluxJobExecutor` does not have any configuration options.
-        :type config: psij.JobExecutorConfig
         """
         # TODO: url is not passed
         # if not url.startswith('flux://'):

--- a/src/psij/executors/local.py
+++ b/src/psij/executors/local.py
@@ -162,6 +162,9 @@ class LocalJobExecutor(JobExecutor):
     """
     A job executor that runs jobs locally using :class:`subprocess.Popen`.
 
+    This job executor is intended to be used when there is no resource manager, only
+    the operating system. Or when there is a resource manager, but it should be ignored.
+
     Limitations: in Linux, attached jobs always appear to complete with a zero exit code regardless
     of the actual exit code.
     """

--- a/src/psij/executors/rp.py
+++ b/src/psij/executors/rp.py
@@ -13,7 +13,11 @@ logger = logging.getLogger(__name__)
 
 
 class RPJobExecutor(JobExecutor):
-    """A job executor that runs jobs via radical.pilot."""
+    """A job executor that runs jobs via radical.pilot.
+
+    The `RADICAL Pilot system
+    <https://radical-cybertools.github.io/radical-pilot/>`_.
+    """
 
     import radical.pilot as _rp
 

--- a/src/psij/job.py
+++ b/src/psij/job.py
@@ -50,7 +50,7 @@ class Job(object):
         # no point in storing integers as strings.
         self._native_id = None  # type: Optional[object]
         self.status_callback = None  # type: Optional[JobStatusCallback]
-        """Setting this property registers a :class:`~psij.JobStatusCallback` with this executor.
+        """Setting this attribute registers a :class:`~psij.JobStatusCallback` with this executor.
         The callback will be invoked whenever a status change occurs for any of the jobs submitted
         to this job executor, whether they were submitted with an individual job status callback or
         not. To remove the callback, set it to `None`."""
@@ -61,22 +61,22 @@ class Job(object):
     @property
     def id(self) -> str:
         """
-        Returns this job’s ID.
+        This job’s ID, read-only.
 
-         The ID is assigned automatically by the implementation when this `Job` object is
-         constructed. The ID is guaranteed to be unique on the machine on which the `Job` object
-         was instantiated. The ID does not have to match the ID of the underlying LRM job, but is
-         used to identify `Job` instances as seen by a client application.
+        The ID is assigned automatically by the implementation when this `Job` object is
+        constructed. The ID is guaranteed to be unique on the machine on which the `Job` object
+        was instantiated. The ID does not have to match the ID of the underlying LRM job, but is
+        used to identify `Job` instances as seen by a client application.
         """
         return self._id
 
     @property
     def native_id(self) -> Optional[str]:
         """
-        Returns the native ID of this job.
+        The ID of this job according to the underlying LRM, read-only.
 
         The native ID may not be available until after the job is submitted to a
-        :class:`~psij.JobExecutor`.
+        :class:`~psij.JobExecutor`, in which case the attribute is ``None``.
         """
         if self._native_id is None:
             return None
@@ -190,8 +190,8 @@ class Job(object):
 
     def __str__(self) -> str:
         """Returns a string representation of this job."""
-        return 'Job[id={}, nativeId={}, executor={}, status={}]'.format(self._id, self._native_id,
-                                                                        self.executor, self.status)
+        return 'Job[id={}, native_id={}, executor={}, status={}]'.format(self._id, self._native_id,
+                                                                         self.executor, self.status)
 
 
 class JobStatusCallback(ABC):

--- a/src/psij/job_executor.py
+++ b/src/psij/job_executor.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class JobExecutor(ABC):
-    """This is an abstract base class for all JobExecutor implementations."""
+    """An abstract base class for all JobExecutor implementations."""
 
     _executors = {}  # type: Dict[str, List[_VersionEntry['JobExecutor']]]
 

--- a/src/psij/launchers/mpirun.py
+++ b/src/psij/launchers/mpirun.py
@@ -7,7 +7,12 @@ from psij.launchers import MultipleLauncher
 
 
 class MPILauncher(MultipleLauncher):
-    """Launches a job using `mpirun`."""
+    """Launches jobs using ``mpirun``.
+
+    ``mpirun`` is a tool provided by
+    `MPI <https://www.mpi-forum.org/>`_ implementations, such as
+    `Open MPI <https://www.open-mpi.org/>`_.
+    """
 
     def __init__(self, config: Optional[JobExecutorConfig] = None):
         """

--- a/src/psij/launchers/srun.py
+++ b/src/psij/launchers/srun.py
@@ -7,7 +7,11 @@ from psij.launchers import MultipleLauncher
 
 
 class SrunLauncher(MultipleLauncher):
-    """Launches a job using Slrum's `srun`."""
+    """Launches a job using Slurm's `srun`.
+
+    See the
+    `Slurm Workload Manager <https://slurm.schedmd.com/overview.html>`_.
+    """
 
     _NAME_ = 'srun'
 


### PR DESCRIPTION
There is still work to do, I just think this is ready to go in and want to keep working on it later.

It is all docstring/docs changes except for one little tweak to ``Job.__str__()``.