### PR TITLE
Web debranding

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -27,11 +27,9 @@
 
 <body>
     <v-app id="psij-app">
-        <v-app-bar elevation="4" height="60pt" fixed elevate-on-scroll width="100%">
+        <v-app-bar elevation="4" height="48pt" fixed elevate-on-scroll width="100%">
             <v-tabs v-model="maintabs" @change="tabChanged">
-                <v-tab href="#index" key="index" class="logo" style="margin: 0 !important">
-                    <img src="images/exaworks-psij-logo.png" width="200" />
-                </v-tab>
+                <v-tab href="#index" key="index"><div class="psi-j-font logo">PSI/J</div></v-tab>
                 <v-tab href="#install" key="install">Install</v-tab>
                 <v-tab href="#docs" key="docs">Documentation</v-tab>
                 <v-tab href="#resources" key="resources">Resources</v-tab>

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>PSI/J - ExaWorks</title>
+    <title>PSI/J - Python</title>
     <!-- must be first for the switcher to work -->
     <link rel="stylesheet" href="theme-4.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">

--- a/web/index.html
+++ b/web/index.html
@@ -306,7 +306,7 @@ $ python setup.py install
             <v-card flat tile class="lighten-1 text-center"
                 style="margin: auto; padding: 2em 0; background-color: #f5f5f5 !important;">
                 <v-card-text>
-                    &copy;2021-{{ new Date().getFullYear() }} - <strong>ExaWorks</strong>
+                    &copy;2021-{{ new Date().getFullYear() }} - <a href="https://exaworks.org">The ExaWorks Project</a>
                 </v-card-text>
 
                 <v-row justify="center">

--- a/web/style.css
+++ b/web/style.css
@@ -55,7 +55,7 @@ body .v-application a {
 
 
 .logo {
-    font-size: 18pt;
+    font-size: 20pt;
 }
 
 .v-tabs .v-tab {

--- a/web/theme-4.css
+++ b/web/theme-4.css
@@ -67,9 +67,6 @@ a.v-tab:focus, a.v-tab:hover {
 }
 
 .logo {
-    background: rgba(255, 255, 255, 0.75); 
     border-radius: 0em !important;
-    border-right: solid 4px;
-    border-color: rgba(255, 255, 255, 0.55);
 }
 


### PR DESCRIPTION
This PR mainly removes "ExaWorks" from the logo. It also:
- makes the navbar smaller
- switches the copyright owner from "ExaWorks" to "The ExaWorks Project" and changes it to a link pointing back to exaworks.
- changes the HTML title from "PSI/J" to "PSI/J - Python".

You can see a visual comparison of the logo/navbar changes below:

![navbar-comp](https://user-images.githubusercontent.com/7749227/167461900-f51ee55d-aada-4012-9539-d07b41ae1f9c.png)

The existence of this PR does not assume that a decision has been made either way, so feel free to discuss.
