### PR TITLE
Web change main font

### DIFF
--- a/web/docs/_static/cloud.css
+++ b/web/docs/_static/cloud.css
@@ -11,7 +11,7 @@
 
 @import url("https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.css");
 @import url("style.css");
-@import url("theme-3.css");
+@import url("theme-4.css");
 @import url("basic.css");
 
 
@@ -28,7 +28,7 @@ html {
 body {
     padding: 0;
     color: #000;
-    font-family: "Gill Sans", sans-serif;
+    font-family: var(--main-font), sans-serif;
     font-size: 100%;
     line-height: 1.5em;
     margin: 0;
@@ -125,7 +125,7 @@ div.sphinxsidebar h3, div.sphinxsidebar h4 {
     padding: 0;
     margin: 24px 16px 0 0;
 
-    font-family: "Gill Sans", sans-serif;
+    font-family: var(--main-font), sans-serif;
     font-weight: normal;
     color: var(--color-fg-norm-1);
 }
@@ -464,7 +464,7 @@ div.body h3,
 div.body h4,
 div.body h5,
 div.body h6 {
-    font-family: "Gill Sans", serif;
+    font-family: var(--main-font), serif;
     font-weight: normal;
     color: var(--color-fg-norm-1);
     clear: both;
@@ -813,7 +813,7 @@ table.docutils th p:last-child, table.docutils td p:last-child {
 table.docutils th {
     border: 0 solid transparent;
     padding: .4em;
-    font-family: "Gill Sans", sans-serif;
+    font-family: var(--main-font), sans-serif;
     background: rgba(0,0,0,.15);
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,7 @@
     <!-- must be first for the switcher to work -->
     <link rel="stylesheet" href="theme-4.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Saira:wght@300&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Saira:wght@300;400&family=Nunito+Sans:wght@300;400display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@6.x/css/materialdesignicons.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
@@ -18,7 +18,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/highlight.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Saira:wght@400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css?id=2">
     <link rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/base16/tender.min.css">

--- a/web/index.html
+++ b/web/index.html
@@ -66,12 +66,12 @@
                                 <v-card align="center" style="padding: 2em; margin-right: 5em">
                                     <div class="icon-logo"><i class="fas fa-server" style="color: #9A3A68"></i></div>
                                     <h3>Write Scheduler Agnostic HPC Applications</h3>
-                                    <p style="color: #666; padding: 0 1em">
+                                    <v-card-text>
                                         Use a unified API to enable your HPC application to run virtually anywhere.
                                         <span class="psi-j-font">PSI/J</span> automatically translates abstract job
                                         specifications into concrete scripts and commands to send to the scheduler.
                                         <span class="psi-j-font">PSI/J</span> is tested on a wide variety of clusters.
-                                    </p>
+                                    </v-card-text>
                                 </v-card>
                             </v-col>
                         </v-row>
@@ -86,11 +86,11 @@
                                     <div class="icon-logo"><i class="fas fa-terminal" style="color: #DD3D5A"></i></div>
                                     <h3><span class="psi-j-font">PSI/J</span> runs entirely in user space</h3>
 
-                                    <p style="color: #666; padding: 0 1em">
+                                    <v-card-text>
                                         There is no need to wait for infrequent deployment cycles. The HPC world
                                         tends to be rather dynamic and the ability to quickly integrate changes
                                         prompted by experimental changes in the cluster environment is essential.
-                                    </p>
+                                    </v-card-text>
                                 </v-card>
                             </v-col>
                             <v-col justify="center">
@@ -99,13 +99,13 @@
                                     </div>
                                     <h3>Use built-in or community contributed plugins</h3>
 
-                                    <p style="color: #666; padding: 0 1em">
+                                    <v-card-text>
                                         Let's be realistic. It is virtually impossible for a single entity to
                                         provide stable and tested adapters to all clusters and schedulers. That is
                                         why <span class="psi-j-font">PSI/J</span> enables and encourages community
                                         contributions to scheduler adapters, testbeds, and specific cluster
                                         knowledge.
-                                    </p>
+                                    </v-card-text>
                                 </v-card>
                             </v-col>
 
@@ -114,12 +114,12 @@
                                     <div class="icon-logo"><i class="fas fa-save" style="color: #FDA214"></i></div>
                                     <h3><span class="psi-j-font">PSI/J</span> has a rich HPC legacy</h3>
 
-                                    <p style="color: #666; padding: 0 1em">
+                                    <v-card-text>
                                         The design of <span class="psi-j-font">PSI/J</span> is based on a number of
                                         libraries used by state of the art HPC workflow applications that the
                                         <span class="psi-j-font">PSI/J</span> team has worked on. Its architectural
                                         foundations have been tested at extreme scales and in diverse environments.
-                                    </p>
+                                    </v-card-text>
                                 </v-card>
                             </v-col>
                         </v-row>

--- a/web/style.css
+++ b/web/style.css
@@ -159,6 +159,7 @@ ul.no-bullet {
 }
 
 .v-card__text {
+    background: transparent !important;
     font-size: 13pt;
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -160,7 +160,7 @@ ul.no-bullet {
 
 .v-card__text {
     background: transparent !important;
-    font-size: 13pt;
+    font-size: 12pt;
 }
 
 ul {
@@ -216,8 +216,9 @@ pre {
     padding: 1em;
 }
 
-.icon-logo {
+#psij-app .icon-logo i {
     font-size: 2em;
     text-align: center;
     width: 100%;
+    font-weight: 900 !important;
 }

--- a/web/theme-4.css
+++ b/web/theme-4.css
@@ -67,7 +67,10 @@
     font-size: 1.2em;
 }
 
-#psij-app h2, #psij-app h3 {
+#psij-app h2,
+#psij-app h2 *,
+#psij-app h3,
+#psij-app h3 * {
     font-weight: 400 !important;
 }
 

--- a/web/theme-4.css
+++ b/web/theme-4.css
@@ -30,6 +30,10 @@
     box-shadow: 0pt 0pt 1pt #8080ff !important;
 }
 
+#psij-app .v-app-bar a {
+    font-weight: 400 !important;
+}
+
 #psij-app .v-card.v-card--flat {
     box-shadow: none !important;
 }

--- a/web/theme-4.css
+++ b/web/theme-4.css
@@ -11,6 +11,17 @@
     --color-link: #6080ff;
     --color-fg-lines: #fe7000;
     --color-global-bg: #ffffff;
+    --main-font: "Nunito Sans" !important;
+}
+
+#psij-app * {
+    font-weight: 300 !important;
+}
+
+#psij-app .fas, 
+#psij-app .fab.
+#psij-app .v-app-bar a {
+    font-weight: 400 !important;
 }
 
 #psij-app .v-card {
@@ -23,14 +34,13 @@
     box-shadow: none !important;
 }
 
-#secondary-banner .v-card, .v-card__title, .v-card__text,
-#secondary-banner .v-card *, #tertiary-banner .v-card * {
-    background-color: #f8f8f8 !important;
-}
-
 #secondary-banner .v-card * {
     background-color: transparent !important; 
     border: 0;
+}
+
+#psij-app .v-card .v-card__text {
+    color: #404040;
 }
 
 .vbox, #secondary-banner .v-card, #psij-app .v-card {
@@ -53,12 +63,8 @@
     font-size: 1.2em;
 }
 
-h2, h3 {
-    font-weight: 400;
-}
-
-h3 {
-    color: #666;
+#psij-app h2, #psij-app h3 {
+    font-weight: 400 !important;
 }
 
 /* Logo related stuff */


### PR DESCRIPTION
This PR changes the main font from Gill Sans to something more in-line with the main website (i.e., a more modern display font with multiple weight variants).

It replaces some of the lighter text with a lighter weight, thus maintaining a similar "visual weight", which is what the main site does.

It also makes the docs font follow the main site font.

Once again, this change is open to discussion.

Comparison below:

![font-comp](https://user-images.githubusercontent.com/7749227/167471446-42b4a459-57c6-473c-aa3b-62b22df0a2fc.png)
