### PR TITLE
Update layout a bit

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -52,18 +52,35 @@
                 <div id="main-banner">
                     <v-container justify="space-around">
                         <v-row justify="center">
-                            <v-col justify="center">
-                                <div>
-                                    <h2>Portable Submission Interface for Jobs</h2>
-                                    <h3>A Python abstraction layer over cluster schedulers</h3>
-                                    <br />
-                                    <img id="big-puzzle" src="https://exaworks.org/images/exaworks-psij.png">
-                                </div>
+                            <v-col class="d-flex align-center justify-center">
+                                <v-card align="center" flat>
+                                    <v-card-title class="text-h5 justify-center">
+                                        Portable Submission Interface for Jobs
+                                    </v-card-title>
+                                    <v-card-text class="justify-center">
+                                        A Python abstraction layer over cluster schedulers
+                                    </v-card-text>
+                                </v-card>
                             </v-col>
-                            <v-col justify="center">
-                                <v-card align="center" style="padding: 2em; margin-right: 5em">
-                                    <div class="icon-logo"><i class="fas fa-server" style="color: #9A3A68"></i></div>
-                                    <h3>Write Scheduler Agnostic HPC Applications</h3>
+                            <v-col class="d-flex align-center justify-center">
+                                <img id="big-puzzle" src="https://exaworks.org/images/exaworks-psij.png">
+                            </v-col>
+                        </v-row>
+                    </v-container>
+                </div>
+
+                <div id="secondary-banner">
+                    <v-container>
+                        <v-row>
+                            <v-col align="center">
+                                <v-card align="center" max-width="400pt">
+                                    <div class="icon-logo">
+                                        <i class="fas fa-server" style="color: #9A4A68"></i>
+                                    </div>
+                                    <v-card-title class="text-h5 justify-center">
+                                        Write Scheduler Agnostic HPC Applications
+                                    </v-card-title>
+
                                     <v-card-text>
                                         Use a unified API to enable your HPC application to run virtually anywhere.
                                         <span class="psi-j-font">PSI/J</span> automatically translates abstract job
@@ -76,7 +93,8 @@
                     </v-container>
                 </div>
 
-                <div id="secondary-banner">
+
+                <div id="tertiary-banner">
                     <v-container>
                         <v-row>
                             <v-col justify="center">

--- a/web/style.css
+++ b/web/style.css
@@ -99,7 +99,6 @@ body .v-application a {
 }
 
 #secondary-banner .v-card {
-    min-height: 20em;
     padding: 1em;
 }
 


### PR DESCRIPTION
This PR changes the layout of some items on the front page. There were some suggestions that the old layout wasn't quite right. So this one splits the first line into two: the firs is a brief description of PSI/J with an image that illustrates that description. The second is the more detailed main card.

This is one possible layout out of many, so we can use this space to discuss other options.

![layout-old](https://user-images.githubusercontent.com/7749227/169097080-1f8a68fe-22b1-414f-b5d4-d1c464857f2d.png)

->

![layout-new](https://user-images.githubusercontent.com/7749227/169097102-1b93679f-2566-4599-bde2-859cbdedc5e1.png)
