### PR TITLE
Web docs fix sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,8 @@ nitpick_ignore = [
     ('py:class', 'distutils.version.Version')
 ]
 
+html_sidebars = {'**': ['globaltoc.html', 'relations.html', 'sourcelink.html', 'searchbox.html']}
+
 # Setup Sphinx extensions (and associated variables)
 extensions = [
     'sphinx.ext.napoleon',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,4 @@
+===============================================================
 Portable Submission Interface for Jobs (PSI/J) - Python Library
 ===============================================================
 
@@ -8,8 +9,9 @@ number of executors and launchers, which are the components that allow
 PSI/J to communicate with specific job schedulers. Currently supported
 schedulers include Slurm, LSF, Flux, PBS Pro, and Cobalt.
 
+
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 3
 
     getting_started
     programming


### PR DESCRIPTION
This PR makes the sidebar not be empty when going to the index page. It also increases the ToC depth to 3 on the index page.