### PR TITLE
More tests

### DIFF
--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -504,6 +504,7 @@ class BatchSchedulerExecutor(JobExecutor):
                     # only read output from submit script if another error message is not
                     # already present
                     status.message = self._read_aux_file(job, '.out')
+                    logger.debug('Output from launcher: %s', status.message)
                 else:
                     self._delete_aux_file(job, '.out')
 
@@ -525,6 +526,7 @@ class BatchSchedulerExecutor(JobExecutor):
             finally:
                 self._delete_aux_file(job=job, suffix=suffix, path=path, force=True)
         else:
+            logger.debug('%s does not exist', path)
             return None
 
     def _delete_aux_file(self, job: Optional[Job] = None, suffix: Optional[str] = None,

--- a/src/psij/launchers/script_based_launcher.py
+++ b/src/psij/launchers/script_based_launcher.py
@@ -104,7 +104,8 @@ class ScriptBasedLauncher(Launcher):
         dst_dir.mkdir(parents=True, exist_ok=True)
         dst_path = dst_dir / path.name
         if dst_path.exists():
-            return dst_path
+            if dst_path.stat().st_mtime >= path.stat().st_mtime:
+                return dst_path
         tmp_prefix = secrets.token_hex() + '_'
         tmp_path = dst_dir / (tmp_prefix + path.name)
         shutil.copy(path, tmp_path)

--- a/src/psij/launchers/script_based_launcher.py
+++ b/src/psij/launchers/script_based_launcher.py
@@ -96,8 +96,11 @@ class ScriptBasedLauncher(Launcher):
             if self._deployed:
                 return
 
-            self._deploy_file(Path(__file__).parent / 'scripts' / 'launcher_lib.sh')
-            self._deployed_script_path = self._deploy_file(self._script_path)
+            self._deploy_files()
+
+    def _deploy_files(self) -> None:
+        self._deploy_file(Path(__file__).parent / 'scripts' / 'launcher_lib.sh')
+        self._deployed_script_path = self._deploy_file(self._script_path)
 
     def _deploy_file(self, path: Path) -> Path:
         dst_dir = self.config.work_directory

--- a/src/psij/launchers/scripts/mpi_launch.sh
+++ b/src/psij/launchers/scripts/mpi_launch.sh
@@ -8,7 +8,7 @@ shift
 pre_launch
 
 set +e
-mpirun -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN
+mpirun --oversubscribe -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN
 _PSI_J_EC=$?
 set -e
 

--- a/src/psij/launchers/scripts/multi_launch.sh
+++ b/src/psij/launchers/scripts/multi_launch.sh
@@ -10,7 +10,7 @@ shift
 export _PSI_J_PROCESS_COUNT
 
 for INDEX in $(seq 1 1 $_PSI_J_PROCESS_COUNT); do
-    _PSI_J_PROCESS_INDEX_=$INDEX "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR  <$_PSI_J_STDIN &
+    _PSI_J_PROCESS_INDEX_=$INDEX "$@" 1>>$_PSI_J_STDOUT 2>>$_PSI_J_STDERR  <$_PSI_J_STDIN &
     PIDS="$PIDS $!"
 done
 

--- a/src/psij/resource_spec.py
+++ b/src/psij/resource_spec.py
@@ -4,14 +4,6 @@ from typing import Optional, List
 from psij.exceptions import InvalidJobException
 
 
-def _nulls(objs: List[object]) -> int:
-    s = 0
-    for e in objs:
-        if e is None:
-            s += 1
-    return s
-
-
 class ResourceSpec(ABC):
     """
     A base class for resource specifications.
@@ -67,7 +59,7 @@ class ResourceSpecV1(ResourceSpec):
         self._check_constraints()
 
     def _check_constraints(self) -> None:
-        nulls = _nulls([self.process_count, self.node_count, self.processes_per_node])
+        nulls = [self.process_count, self.node_count, self.processes_per_node].count(None)
         self._computed_process_count = self.process_count
         self._computed_node_count = self.node_count
         self._computed_ppn = self.processes_per_node

--- a/src/psij/resource_spec.py
+++ b/src/psij/resource_spec.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, List
+from typing import Optional
 
 from psij.exceptions import InvalidJobException
 

--- a/src/psij/resource_spec.py
+++ b/src/psij/resource_spec.py
@@ -88,14 +88,20 @@ class ResourceSpecV1(ResourceSpec):
                 self._computed_node_count = 1
         elif nulls == 1:
             if self.process_count is None:
+                assert self.node_count is not None
+                assert self.processes_per_node is not None
                 self._computed_process_count = int(self.node_count * self.processes_per_node)
             elif self.node_count is None:
+                assert self.process_count is not None
+                assert self.processes_per_node is not None
                 if self.process_count % self.processes_per_node != 0:
                     raise InvalidJobException('The process_count (%s) must be an integral multiple'
                                               ' of processes_per_node (%s)' %
                                               (self.process_count, self.processes_per_node))
                 self._computed_node_count = self.process_count // self.processes_per_node
             else:
+                assert self.process_count is not None
+                assert self.node_count is not None
                 if self.process_count % self.node_count != 0:
                     raise InvalidJobException('The process_count (%s) must be an integral multiple'
                                               ' of node_count (%s)' %
@@ -103,6 +109,9 @@ class ResourceSpecV1(ResourceSpec):
                 self._computed_ppn = self.process_count // self.node_count
         else:
             # all specified
+            assert self.process_count is not None
+            assert self.node_count is not None
+            assert self.processes_per_node is not None
             if self.process_count != self.node_count * self.processes_per_node:
                 raise InvalidJobException('The resources must satisfy the constraint '
                                           'process_count (%s) = node_count (%s) * '
@@ -120,6 +129,7 @@ class ResourceSpecV1(ResourceSpec):
 
         :return: An integer value with the specified or calculated node count.
         """
+        assert self._computed_node_count is not None
         return self._computed_node_count
 
     @property
@@ -133,6 +143,7 @@ class ResourceSpecV1(ResourceSpec):
         :return: An integer value with either the value of `process_count` or one if the
             former is not specified.
         """
+        assert self._computed_process_count is not None
         return self._computed_process_count
 
     @property
@@ -146,6 +157,7 @@ class ResourceSpecV1(ResourceSpec):
         :return: An integer value with either the value of `processes_per_node` or one if the
             former cannot be determined.
         """
+        assert self._computed_ppn is not None
         return self._computed_ppn
 
     @property

--- a/tests/_test_tools.py
+++ b/tests/_test_tools.py
@@ -20,10 +20,22 @@ def _get_timeout(execparams: ExecutorTestParams) -> Optional[timedelta]:
         return None
 
 
-def assert_completed(status: Optional[JobStatus]) -> None:
+def _read_file(path: Optional[Path]) -> str:
+    if path is None:
+        return ''
+
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def assert_completed(job: Job, status: Optional[JobStatus]) -> None:
     assert status is not None
     if status.state != JobState.COMPLETED:
-        raise AssertionError('Job not completed. Status message: %s' % status.message)
+        assert job.spec is not None
+        stdout = _read_file(job.spec.stdout_path)
+        stderr = _read_file(job.spec.stderr_path)
+        raise AssertionError('Job not completed. Status message: %s, stdout: %s, stderr: %s'
+                             % (status.message, stdout, stderr))
 
 
 def _get_executor_instance(ep: ExecutorTestParams, job: Job) -> JobExecutor:

--- a/tests/_test_tools.py
+++ b/tests/_test_tools.py
@@ -1,0 +1,33 @@
+from datetime import timedelta
+from pathlib import Path
+from typing import Optional
+
+from executor_test_params import ExecutorTestParams
+
+from psij import JobStatus, JobState, Job, JobExecutor, JobAttributes
+
+_QUICK_EXECUTORS = set(['local', 'batch-test'])
+
+
+def _make_test_dir() -> None:
+    (Path.home() / '.psij' / 'test').mkdir(parents=True, exist_ok=True)
+
+
+def _get_timeout(execparams: ExecutorTestParams) -> Optional[timedelta]:
+    if execparams.executor in _QUICK_EXECUTORS:
+        return timedelta(minutes=10)
+    else:
+        return None
+
+
+def assert_completed(status: Optional[JobStatus]) -> None:
+    assert status is not None
+    if status.state != JobState.COMPLETED:
+        raise AssertionError('Job not completed. Status message: %s' % status.message)
+
+
+def _get_executor_instance(ep: ExecutorTestParams, job: Job) -> JobExecutor:
+    assert job.spec is not None
+    job.spec.launcher = ep.launcher
+    job.spec.attributes = JobAttributes(custom_attributes=ep.custom_attributes)
+    return JobExecutor.get_instance(ep.executor, url=ep.url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,8 @@ def _get_executors(config: Dict[str, str]) -> List[str]:
 
 def _translate_executor(config: Dict[str, str], executor: str) -> List[str]:
     if executor == 'auto':
-        execs = ['local:single', 'local:multiple', 'batch-test:single', 'batch-test:multiple']
+        execs = ['local:single', 'local:multiple', 'batch-test:single', 'batch-test:multiple',
+                 'batch-test:batch-test']
         queue_execs = _translate_executor(config, 'auto_q')
         assert len(queue_execs) in [0, 1]
         queue_exec = None

--- a/tests/plugins1/_batch_test/test/hostname
+++ b/tests/plugins1/_batch_test/test/hostname
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+HOSTNAME=`/bin/hostname "$@"`
+echo "${HOSTNAME}-${_PSI_J_NODE_INDEX_}"

--- a/tests/plugins1/_batch_test/test/launcher.sh
+++ b/tests/plugins1/_batch_test/test/launcher.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+source $(dirname "$0")/launcher_lib.sh
+
+pre_launch
+
+log "Args: $@"
+
+PIDS=""
+_PSI_J_PROCESS_COUNT="$1"
+_PSI_J_NODE_COUNT="$2"
+_PSI_J_PPN="$3"
+shift 3
+export _PSI_J_PROCESS_COUNT
+export _PSI_J_NODE_COUNT
+export _PSI_J_PPN
+
+EXECUTABLE="$1"
+shift
+if [ "$EXECUTABLE" == "/bin/hostname" ]; then
+    EXECUTABLE=$(dirname "$0")/hostname
+fi
+
+log "Running stuff"
+log "Stdout: $_PSI_J_STDOUT"
+
+for NODE in $(seq 1 1 $_PSI_J_NODE_COUNT); do
+    log "Node: $NODE"
+    for NODE_PROC in $(seq 1 1 $_PSI_J_PPN); do
+        log "Node proc: $NODE_PROC"
+        INDEX=$(($NODE * $_PSI_J_PPN + $NODE_PROC))
+        log "Index: $INDEX"
+        _PSI_J_NODE_INDEX_=$NODE _PSI_J_PROCESS_INDEX_=$INDEX "$EXECUTABLE" "$@" 1>>$_PSI_J_STDOUT 2>>$_PSI_J_STDERR  <$_PSI_J_STDIN &
+        PIDS="$PIDS $!"
+    done
+done
+
+for PID in $PIDS ; do
+    set +e
+    wait $PID
+    _PSI_J_EC=$?
+    set -e
+    if [ "$_PSI_J_EC" != "0" ]; then
+        log "Pid $PID failed with $_PSI_J_EC"
+        _PSI_J_FAILED_EC=$_PSI_J_EC
+    fi
+done
+
+log "All completed"
+
+post_launch
+
+echo "_PSI_J_LAUNCHER_DONE"
+exit $_PSI_J_FAILED_EC

--- a/tests/plugins1/psij-descriptors/descriptors.py
+++ b/tests/plugins1/psij-descriptors/descriptors.py
@@ -22,3 +22,8 @@ __PSI_J_EXECUTORS__ = [
                cls='_batch_test._batch_test._TestJobExecutor')
 
 ]
+
+__PSI_J_LAUNCHERS__ = [
+    Descriptor(name='batch-test', version=StrictVersion('0.0.1'),
+               cls='_batch_test._batch_test._TestLauncher')
+]

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,37 +1,11 @@
-from datetime import timedelta
+import uuid
 from pathlib import Path
-from typing import Optional
 
-from psij import SubmitException, Job, JobExecutor, JobSpec, JobState, JobAttributes, JobStatus
+from psij import SubmitException, Job, JobSpec, JobState
 from tempfile import TemporaryDirectory
 
 from executor_test_params import ExecutorTestParams
-
-
-_QUICK_EXECUTORS = set(['local', 'batch-test'])
-
-
-def _make_test_dir() -> None:
-    (Path.home() / '.psij' / 'test').mkdir(parents=True, exist_ok=True)
-
-
-def _get_timeout(execparams: ExecutorTestParams) -> Optional[timedelta]:
-    if execparams.executor in _QUICK_EXECUTORS:
-        return timedelta(minutes=10)
-    else:
-        return None
-
-
-def assert_completed(status: Optional[JobStatus]) -> None:
-    assert status is not None
-    assert status.state == JobState.COMPLETED
-
-
-def _get_executor_instance(ep: ExecutorTestParams, job: Job) -> JobExecutor:
-    assert job.spec is not None
-    job.spec.launcher = ep.launcher
-    job.spec.attributes = JobAttributes(custom_attributes=ep.custom_attributes)
-    return JobExecutor.get_instance(ep.executor, url=ep.url)
+from _test_tools import _get_executor_instance, _get_timeout, assert_completed, _make_test_dir
 
 
 def test_simple_job(execparams: ExecutorTestParams) -> None:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -13,7 +13,7 @@ def test_simple_job(execparams: ExecutorTestParams) -> None:
     ex = _get_executor_instance(execparams, job)
     ex.submit(job)
     status = job.wait(timeout=_get_timeout(execparams))
-    assert_completed(status)
+    assert_completed(job, status)
 
 
 def test_simple_job_redirect(execparams: ExecutorTestParams) -> None:
@@ -24,7 +24,7 @@ def test_simple_job_redirect(execparams: ExecutorTestParams) -> None:
         ex = _get_executor_instance(execparams, job)
         ex.submit(job)
         status = job.wait(timeout=_get_timeout(execparams))
-        assert_completed(status)
+        assert_completed(job, status)
         f = outp.open("r")
         contents = f.read()
         f.close()
@@ -42,7 +42,7 @@ def test_attach(execparams: ExecutorTestParams) -> None:
     job2 = Job()
     ex.attach(job2, native_id)
     status = job2.wait(timeout=_get_timeout(execparams))
-    assert_completed(status)
+    assert_completed(job2, status)
 
 
 def test_cancel(execparams: ExecutorTestParams) -> None:
@@ -92,8 +92,8 @@ def test_parallel_jobs(execparams: ExecutorTestParams) -> None:
     ex.submit(job2)
     status1 = job1.wait(timeout=_get_timeout(execparams))
     status2 = job2.wait(timeout=_get_timeout(execparams))
-    assert_completed(status1)
-    assert_completed(status2)
+    assert_completed(job1, status1)
+    assert_completed(job2, status2)
 
 
 def test_env_var(execparams: ExecutorTestParams) -> None:
@@ -107,7 +107,7 @@ def test_env_var(execparams: ExecutorTestParams) -> None:
         ex = _get_executor_instance(execparams, job)
         ex.submit(job)
         status = job.wait(timeout=_get_timeout(execparams))
-        assert_completed(status)
+        assert_completed(job, status)
         f = outp.open("r")
         contents = f.read()
         f.close()
@@ -129,7 +129,7 @@ def test_stdin_redirect(execparams: ExecutorTestParams) -> None:
         ex = _get_executor_instance(execparams, job)
         ex.submit(job)
         status = job.wait(timeout=_get_timeout(execparams))
-        assert_completed(status)
+        assert_completed(job, status)
 
         with open(outp, 'r') as outf:
             contents = outf.read()

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1,0 +1,64 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from psij import Job, JobSpec, ResourceSpecV1
+from tempfile import TemporaryDirectory
+
+from executor_test_params import ExecutorTestParams
+from _test_tools import _get_executor_instance, _get_timeout, assert_completed, _make_test_dir
+
+
+RANK_VARS = ['PMIX_RANK', 'OMPI_COMM_WORLD_RANK', 'PMI_RANK', 'MV2_COMM_WORLD_RANK']
+logger = logging.getLogger(__name__)
+
+
+def _check_ranks(s: str, rank_var: str, n: int) -> bool:
+    expected = set([str(x) for x in range(n)])
+    lines = s.splitlines()
+
+    rank_var = rank_var + '='
+    for line in lines:
+        if line.startswith(rank_var):
+            value = line[len(rank_var):]
+            if value not in expected:
+                pytest.fail('Unexpected rank value in output: %s' % value)
+            expected.remove(value)
+
+    if len(expected) == 0:
+        return True
+    if len(expected) == n:
+        return False
+
+    pytest.fail('Only some of the expected ranks were found in output. Missing ranks: %s'
+                % expected)
+
+
+def test_basic_mpi(execparams: ExecutorTestParams) -> None:
+    if execparams.launcher != 'mpirun':
+        pytest.skip('This test requires mpirun')
+
+    _make_test_dir()
+
+    n_ranks = 4
+
+    with TemporaryDirectory(dir=Path.home() / '.psij' / 'test') as td:
+        outp = Path(td, 'stdout.txt')
+        job = Job(JobSpec(executable='/bin/bash', arguments=['-c', 'env | grep RANK'],
+                          stdout_path=outp, launcher=execparams.launcher))
+        job.spec.resources = ResourceSpecV1(process_count=n_ranks)
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert_completed(status)
+
+        with open(outp, 'r') as outf:
+            result = outf.read()
+        logger.info("Output from job: %s", result)
+
+        for rank_var in RANK_VARS:
+            if _check_ranks(result, rank_var, n_ranks):
+                # success
+                return
+        pytest.fail('No rank variables found in output')

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -45,8 +45,9 @@ def test_basic_mpi(execparams: ExecutorTestParams) -> None:
 
     with TemporaryDirectory(dir=Path.home() / '.psij' / 'test') as td:
         outp = Path(td, 'stdout.txt')
+        errp = Path(td, 'stderr.txt')
         job = Job(JobSpec(executable='/bin/bash', arguments=['-c', 'env | grep RANK'],
-                          stdout_path=outp, launcher=execparams.launcher))
+                          stdout_path=outp, stderr_path=errp, launcher=execparams.launcher))
         assert job.spec is not None
         job.spec.resources = ResourceSpecV1(process_count=n_ranks)
         ex = _get_executor_instance(execparams, job)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -52,7 +52,7 @@ def test_basic_mpi(execparams: ExecutorTestParams) -> None:
         ex = _get_executor_instance(execparams, job)
         ex.submit(job)
         status = job.wait(timeout=_get_timeout(execparams))
-        assert_completed(status)
+        assert_completed(job, status)
 
         with open(outp, 'r') as outf:
             result = outf.read()

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -47,6 +47,7 @@ def test_basic_mpi(execparams: ExecutorTestParams) -> None:
         outp = Path(td, 'stdout.txt')
         job = Job(JobSpec(executable='/bin/bash', arguments=['-c', 'env | grep RANK'],
                           stdout_path=outp, launcher=execparams.launcher))
+        assert job.spec is not None
         job.spec.resources = ResourceSpecV1(process_count=n_ranks)
         ex = _get_executor_instance(execparams, job)
         ex.submit(job)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -78,7 +78,7 @@ def test_nodes(execparams: ExecutorTestParams) -> None:
         ex = _get_executor_instance(execparams, job)
         ex.submit(job)
         status = job.wait(timeout=_get_timeout(execparams))
-        assert_completed(status)
+        assert_completed(job, status)
 
         with open(outp, 'r') as outf:
             result = outf.read()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,91 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from psij import Job, JobSpec, ResourceSpecV1, InvalidJobException
+from tempfile import TemporaryDirectory
+
+from executor_test_params import ExecutorTestParams
+from _test_tools import _get_executor_instance, _get_timeout, assert_completed, _make_test_dir
+
+
+logger = logging.getLogger(__name__)
+
+
+def test_resource_constraints() -> None:
+    ResourceSpecV1()
+    ResourceSpecV1(process_count=2)
+    ResourceSpecV1(node_count=2)
+    ResourceSpecV1(processes_per_node=2)
+    ResourceSpecV1(process_count=4, node_count=2)
+    ResourceSpecV1(process_count=4, processes_per_node=2)
+    ResourceSpecV1(process_count=4, node_count=2, processes_per_node=2)
+
+
+def _failingResourceSpecV1(**kwargs) -> None:
+    try:
+        ResourceSpecV1(**kwargs)
+        pytest.fail('Should have failed: %s' % kwargs)
+    except InvalidJobException:
+        pass
+
+
+def test_failing_resource_constraints() -> None:
+    _failingResourceSpecV1(process_count=3, node_count=2)
+    _failingResourceSpecV1(process_count=3, processes_per_node=2)
+    _failingResourceSpecV1(process_count=8, node_count=2, processes_per_node=2)
+
+
+def _check_ranks(s: str, expected_ranks: int, expected_nodes: int) -> bool:
+    lines = s.splitlines()
+    unique_hosts = set()
+    rank_count = 0
+
+    for line in lines:
+        line = line.strip()
+        if line == '':
+            continue
+        rank_count += 1
+        unique_hosts.add(line)
+
+    if len(unique_hosts) != expected_nodes:
+        pytest.fail('Wrong number of nodes. Expected %s, got %s' % (expected_nodes, unique_hosts))
+    if rank_count != expected_ranks:
+        pytest.fail('Wrong number of ranks. Expected %s, got %s' % (expected_ranks, rank_count))
+
+
+def test_nodes(execparams: ExecutorTestParams) -> None:
+    if not _supported(execparams):
+        pytest.skip('Unsupported executor/launcher combination')
+
+    _make_test_dir()
+
+    n_ranks = 4
+    n_nodes = 2
+    ppn = n_ranks / n_nodes
+
+    with TemporaryDirectory(dir=Path.home() / '.psij' / 'test') as td:
+        outp = Path(td, 'stdout.txt')
+        job = Job(JobSpec(executable='/bin/hostname', stdout_path=outp,
+                          launcher=execparams.launcher))
+        job.spec.resources = ResourceSpecV1(node_count=n_nodes, processes_per_node=ppn)
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert_completed(status)
+
+        with open(outp, 'r') as outf:
+            result = outf.read()
+        logger.info("Output from job: %s", result)
+
+        _check_ranks(result, n_ranks, n_nodes)
+
+
+def _supported(ep: ExecutorTestParams) -> bool:
+    if ep.executor == 'batch-test':
+        return ep.launcher == 'batch-test'
+    if ep.executor in ['slurm', 'pbs', 'lsf']:
+        return ep.launcher in ['mpirun', 'srun', 'ibrun']
+
+    return False


### PR DESCRIPTION
This PR started as an effort to add more tests, particularly in the direction of resource specification/allocation.

It needed some local validation, so a test launcher was added that can fake multiple hosts.

As a side effect, ResourceSpecV1 was also revamped a bit: it made no sense that one couldn't specify, say `process_count=4` and `node_count=2`. That is now possible. ResourceSpecV1 checks basic constraints, such as `process_count % node_count = 0`, `process_count = node_count * ppn`. It can also infer some of these numbers if they are not otherwise specified. However, whether the inferred numbers are used or not by an executor is left to the executor.