### PR TITLE
Use per-process deployment directories for launcher files

### DIFF
--- a/src/psij/launchers/script_based_launcher.py
+++ b/src/psij/launchers/script_based_launcher.py
@@ -68,6 +68,8 @@ class _ProcessSandbox:
 
     def clean(self) -> None:
         now = time.time()
+        if not self.config.work_directory.exists():
+            return
         for child in self.config.work_directory.iterdir():
             if child.name.startswith(_SANDBOX_PREFIX):
                 marker = child / '.stale'

--- a/src/psij/launchers/script_based_launcher.py
+++ b/src/psij/launchers/script_based_launcher.py
@@ -55,6 +55,7 @@ class _ProcessSandbox:
             return self.dir
 
     def create(self) -> None:
+        self.config.work_directory.mkdir(parents=True, exist_ok=True)
         self.dir = Path(tempfile.mkdtemp(prefix=_SANDBOX_PREFIX, dir=self.config.work_directory))
         self.created = True
 


### PR DESCRIPTION
Unfortunately, a single directory can lead to clashes between versions and processes.