### PR TITLE
Setup version info

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,4 +60,6 @@ jobs:
           pip install -r requirements-connector-radical.txt
           make launcher-scripts
           make install
-          PYTHONPATH=$(flux env | grep PYTHONPATH | sed -E 's/.*PYTHONPATH="(.*)"/\1/') OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 make tests
+          ref_name="${{ github.ref_name }}"
+          echo "ref_name : $ref_name"
+          PYTHONPATH=$(flux env | grep PYTHONPATH | sed -E 's/.*PYTHONPATH="(.*)"/\1/') OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 make tests -- --branch-name-override $ref_name

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup, find_packages
 
+with open("src/psij/version.py") as f:
+    exec(f.read())
+
 
 if __name__ == '__main__':
     with open('requirements.txt') as f:
@@ -7,7 +10,7 @@ if __name__ == '__main__':
 
     setup(
         name='psi-j-python',
-        version='0.1',
+        version=VERSION,
 
         description='''This is an implementation of the J/PSI (Portable Submission Interface for Jobs)
         specification.''',

--- a/src/psij/__init__.py
+++ b/src/psij/__init__.py
@@ -18,7 +18,9 @@ from .job_state import JobState
 from .job_status import JobStatus
 from .resource_spec import ResourceSpec, ResourceSpecV1
 from .serialize import Export, Import
+from .version import VERSION
 
+__version__ = VERSION
 
 __all__ = [
     'JobExecutor', 'JobExecutorConfig', 'Job', 'JobStatusCallback', 'JobSpec', 'JobAttributes',

--- a/src/psij/version.py
+++ b/src/psij/version.py
@@ -1,0 +1,6 @@
+"""Set module version.
+
+<Major>.<Minor>.<maintenance>[alpha/beta/..]
+Alphas will be numbered like this -> 1.0.0-a0
+"""
+VERSION = '1.0.0-a0'


### PR DESCRIPTION
This PR splits out changes in #226 to support better version info handling.
 
* version info is now set in the module `src/psij/version.py`
* updates to `setup.py` to use the above
* `psij.__version__` will work now.