### PR TITLE
Adding deploy scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,10 @@ install:
 .PHONY: develop
 develop:
 	$(PYTHON) setup.py develop
+
+
+.PHONY: tag-and-release
+tag: ## create a tag in git. to run, do a 'make VERSION="version string" tag-and-release
+	./tag_and_release.sh create_tag $(VERSION)
+	./tag_and_release.sh package
+	./tag_and_release.sh release

--- a/tag_and_release.sh
+++ b/tag_and_release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euf -o pipefail
+
+create_tag () {
+    if [ -z "$1" ]
+      then
+        VERSION="unknown"
+      else
+        VERSION=$1
+    fi
+
+    PSIJ_VERSION=$(python3 -c "import psij; print(psij.__version__)")
+
+    if [[ $PSIJ_VERSION == "$VERSION" ]]
+    then
+        echo "Version requested matches package version: $VERSION"
+    else
+        echo "[ERROR] Version mismatch. User request: '$VERSION' while package version is: '$PSIJ_VERSION'"
+        exit 1
+    fi
+
+    echo "Creating tag"
+    git tag -a "$VERSION" -m "Psij $VERSION"
+
+    echo "Pushing tag"
+    git push origin --tags
+
+}
+
+package() {
+
+    rm -f dist/*
+
+    echo "======================================================================="
+    echo "Starting clean builds"
+    echo "======================================================================="
+    python3 setup.py sdist
+    python3 setup.py bdist_wheel
+
+    echo "======================================================================="
+    echo "Done with builds"
+    echo "======================================================================="
+
+
+}
+
+release () {
+    echo "======================================================================="
+    echo "Push to PyPi. This will require your username and password"
+    echo "======================================================================="
+    twine upload dist/*
+}
+
+"$@"


### PR DESCRIPTION
Adding deploy scripts and matching changes to the `Makefile`.

Here are the deploy steps I recommend:
1. Create a branch off of main once ready to deploy
2. Bump the version info, docs etc in the branch
3. Review and merge to main
4. Run the following to deploy from main 
```
make VERSION=<version_info> tag-and-release
```

The above call will make a github tag, and deploy to pypi, so make sure to have your pypi creds handy.

