### PR TITLE
Fail early if git info cannot be obtained and saving or uploading is …

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           cd /workspace
           git --version
+          git branch -a
           # git can complain about "dubious ownership" without this
           # we mark it as safe here since it's an ephemeral container anyway
           git config --global --add safe.directory /workspace

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,6 +44,9 @@ jobs:
         options: -v ${{ github.workspace }}:/workspace -u root
         run: |
           cd /workspace
+          # git can complain about "dubious ownership" without this
+          # we mark it as safe here since it's an ephemeral container anyway
+          git config --global --add safe.directory /workspace
           echo "Running in ${PWD}"
           sudo apt update
           sudo apt install -y openssh-server openssh-client

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,6 +44,7 @@ jobs:
         options: -v ${{ github.workspace }}:/workspace -u root
         run: |
           cd /workspace
+          git --version
           # git can complain about "dubious ownership" without this
           # we mark it as safe here since it's an ephemeral container anyway
           git config --global --add safe.directory /workspace

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,11 +44,6 @@ jobs:
         options: -v ${{ github.workspace }}:/workspace -u root
         run: |
           cd /workspace
-          git --version
-          git branch -a
-          # git can complain about "dubious ownership" without this
-          # we mark it as safe here since it's an ephemeral container anyway
-          git config --global --add safe.directory /workspace
           echo "Running in ${PWD}"
           sudo apt update
           sudo apt install -y openssh-server openssh-client
@@ -65,6 +60,4 @@ jobs:
           pip install -r requirements-connector-radical.txt
           make launcher-scripts
           make install
-          ref_name="${{ github.ref_name }}"
-          echo "ref_name : $ref_name"
-          PYTHONPATH=$(flux env | grep PYTHONPATH | sed -E 's/.*PYTHONPATH="(.*)"/\1/') OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 make tests -- --branch-name-override $ref_name
+          PYTHONPATH=$(flux env | grep PYTHONPATH | sed -E 's/.*PYTHONPATH="(.*)"/\1/') OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 make tests

--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -217,7 +217,7 @@ class BatchSchedulerExecutor(JobExecutor):
         self._queue_poll_thread.register_job(job)
 
     def _get_launcher_from_job(self, job: Job) -> Launcher:
-        assert(job.spec)
+        assert job.spec
         launcher_name = job.spec.launcher
         if not launcher_name:
             launcher_name = Launcher.DEFAULT_LAUNCHER_NAME

--- a/src/psij/executors/batch/lsf.py
+++ b/src/psij/executors/batch/lsf.py
@@ -65,7 +65,7 @@ class LsfJobExecutor(BatchSchedulerExecutor):
         self, job: Job, context: Dict[str, object], submit_file: TextIO
     ) -> None:
         """See :meth:`~.BatchSchedulerExecutor.generate_submit_script`."""
-        assert(job.spec is not None)
+        assert job.spec is not None
         context["job_duration"] = int(job.spec.attributes.duration.total_seconds() // 60)
         self.generator.generate_submit_script(job, context, submit_file)
 

--- a/src/psij/serialize.py
+++ b/src/psij/serialize.py
@@ -99,7 +99,7 @@ class Import():
     def from_dict(self, hash: Dict[str, Any], target_type: Optional[str] = None) -> object:
         """Reads an object from a dict."""
         if target_type == "JobSpec":
-            return(self._dict2spec(hash))
+            return self._dict2spec(hash)
         else:
             sys.exit("Can't create dict,  type " + str(target_type) + " not supported")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,13 +364,8 @@ def _discover_environment(config):
     env['in_venv'] = _get_env('VIRTUAL_ENV') != ''
     config.option.custom_attributes = _parse_custom_attributes(
         config.getoption('custom_attributes'))
+
     try:
-        env['has_slurm'] = shutil.which('sbatch') is not None
-        env['has_mpirun'] = shutil.which('mpirun') is not None
-        env['has_flux'] = _has_flux()
-        env['can_ssh_to_localhost'] = _try_run_command(['ssh', '-oBatchMode=yes',
-                                                        '-oStrictHostKeyChecking=no', 'localhost',
-                                                        'true'], timeout=5)
         env['git_branch'] = _get_git_branch(config)
         env['git_last_commit'] = _get_last_commit()
         ahead, behind = _get_commit_diff()
@@ -378,6 +373,21 @@ def _discover_environment(config):
         env['git_behind_remote_commit_count'] = behind
         env['git_local_change_summary'] = _get_git_diff_stat()
         env['git_has_local_changes'] = (env['git_local_change_summary'] != '')
+    except Exception as ex:
+        logger.exception(ex)
+        save = config.getoption('save_results')
+        upload = config.getoption('upload_results')
+        if save or upload:
+            raise Exception('Cannot get required repository information.')
+        else:
+            logger.warning('Cannot get git repository information.')
+    try:
+        env['has_slurm'] = shutil.which('sbatch') is not None
+        env['has_mpirun'] = shutil.which('mpirun') is not None
+        env['has_flux'] = _has_flux()
+        env['can_ssh_to_localhost'] = _try_run_command(['ssh', '-oBatchMode=yes',
+                                                        '-oStrictHostKeyChecking=no', 'localhost',
+                                                        'true'], timeout=5)
     except Exception as ex:
         env['error'] = str(ex)
     config.option.environment = env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,8 +265,11 @@ def _get_id(config):
 
 
 def _run(*args) -> str:
-    process = subprocess.run(args, check=True, text=True,
+    process = subprocess.run(args, check=False, text=True,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if process.returncode != 0:
+        raise Exception('Command %s failed with exit code %s. Output: %s, %s' %
+                        (args, process.returncode, process.stdout, process.stderr))
     return process.stdout.strip()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,21 +212,24 @@ def _get_config_env(config, name):
 
 
 def pytest_unconfigure(config):
-    data = {
-        'module': '_conftest',
-        'cls': None,
-        'function': '_end',
-        'test_name': '_end',
-        'results': {},
-        'extras': None,
-        'test_start_time': _now(),
-        'test_end_time': _now(),
-        'run_id': _get_config_env(config, 'run_id'),
-        'branch': _get_config_env(config, 'git_branch')
-    }
-    if hasattr(config.option, 'environment'):
-        # only upload if we were able to get a basic environment
-        _save_or_upload(config, data)
+    save = config.getoption('save_results')
+    upload = config.getoption('upload_results')
+    if save or upload:
+        data = {
+            'module': '_conftest',
+            'cls': None,
+            'function': '_end',
+            'test_name': '_end',
+            'results': {},
+            'extras': None,
+            'test_start_time': _now(),
+            'test_end_time': _now(),
+            'run_id': _get_config_env(config, 'run_id'),
+            'branch': _get_config_env(config, 'git_branch')
+        }
+        if hasattr(config.option, 'environment'):
+            # only upload if we were able to get a basic environment
+            _save_or_upload(config, data)
 
 
 def _cache(file_path, fn):


### PR DESCRIPTION
…enabled.

Otherwise print a warning and continue.

This also disables the building of the data package for upload or save in test suite teardown if neither saving or uploading are enabled.

The basic issue with getting git info in gh actions is that using checkout/v2 checks out a particular hash with a detached head. That causes most complex git stuff to fail. However, said complex git stuff is only used to collect data for saving or uploading and not when running tests otherwise.