### PR TITLE
Minimal test uploads

### DIFF
--- a/testing.conf
+++ b/testing.conf
@@ -68,6 +68,9 @@ scope = core
 #   - the maintainer email, if one is provided
 #   - boolean values, such as whether the target system has mpirun available,
 #     etc.
+#   - git identifiers and counts: branch name, last commit hash, how many 
+#     commits the local code has ahead/behind of the remote, and if there
+#     are any local changes
 #   - the result status of tests, excluding string error messages coming from
 #     tests
 #

--- a/testing.conf
+++ b/testing.conf
@@ -81,7 +81,8 @@ scope = core
 #
 # The full information is still saved locally and can be accessed and manually
 # vetted if required. Setting this to "true" automatically enables saving of
-# results to files.
+# results to files. Please note that this option modifies the behavior of 
+# uploads, which must still be requested using the "--upload-results" flag.
 #
 # minimal_uploads = false | true
 

--- a/testing.conf
+++ b/testing.conf
@@ -59,6 +59,33 @@ scope = core
 
 
 #
+# Enables minimal uploads mode. In minimal mode, no information that is 
+# potentially sensitive is uploaded to the test results server. Specifically, 
+# only the following are uploaded:
+#   - code related identifiers, such as branch names, class names, etc.
+#   - times and dates
+#   - test related identifiers, such as run id
+#   - the maintainer email, if one is provided
+#   - boolean values, such as whether the target system has mpirun available,
+#     etc.
+#   - the result status of tests, excluding string error messages coming from
+#     tests
+#
+# Excluded items include, but are not limited to:
+#   - stdout/stderr from tests
+#   - logs from tests
+#   - filesystem paths
+#
+# The full information is still saved locally and can be accessed and manually
+# vetted if required. Setting this to "true" automatically enables saving of
+# results to files.
+#
+# minimal_uploads = false | true
+
+minimal_uploads = false
+
+
+#
 # Which executors to test. This is a comma separated list of
 # <executor_name>[:<launcher_name>[:<url>]] items. The "auto_q" executor means
 # that the testing infrastructure will attempt to determine which queuing system

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -117,7 +117,7 @@ def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool =
         args.append('--branch-name-override')
         args.append(fake_branch_name)
     for opt in ['maintainer_email', 'executors', 'server_url', 'key', 'max_age',
-                'custom_attributes']:
+                'custom_attributes', 'minimal_uploads']:
         try:
             val = get_conf(conf, opt)
             args.append('--' + opt.replace('_', '-'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -481,10 +481,10 @@ def _save_report(config, data):
 _SAFE_KEYS = ['module', 'cls', 'function', 'test_name', 'test_start_time', 'test_end_time',
               'run_id', 'branch', 'results.setup.passed', 'results.setup.status',
               'results.call.passed', 'results.call.status', 'results.teardown.passed',
-              'results.teardown.status', 'extras.executors', 'extras.maintainer_email',
-              'extras.start_time', 'extras.run_id', 'extras.git_branch', 'extras.git_last_commit',
-              'extras.git_ahead_remote_commit_count', 'extras.git_behind_remote_commit_count',
-              'extras.git_local_change_summary', 'extras.git_has_local_changes']
+              'results.teardown.status', 'extras.start_time', 'extras.run_id', 'extras.git_branch',
+              'extras.git_last_commit', 'extras.git_ahead_remote_commit_count',
+              'extras.git_behind_remote_commit_count',  'extras.git_has_local_changes',
+              'extras.config.id', 'extras.config.executors', 'extras.config.maintainer_email']
 _SAFE_KEYS_PROCESSED = None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -483,7 +483,7 @@ _SAFE_KEYS = ['module', 'cls', 'function', 'test_name', 'test_start_time', 'test
               'results.call.passed', 'results.call.status', 'results.teardown.passed',
               'results.teardown.status', 'extras.start_time', 'extras.run_id', 'extras.git_branch',
               'extras.git_last_commit', 'extras.git_ahead_remote_commit_count',
-              'extras.git_behind_remote_commit_count',  'extras.git_has_local_changes',
+              'extras.git_behind_remote_commit_count', 'extras.git_has_local_changes',
               'extras.config.id', 'extras.config.executors', 'extras.config.maintainer_email']
 _SAFE_KEYS_PROCESSED = {}
 
@@ -517,7 +517,7 @@ def _do_sanitize(data: Dict[str, object], result: Dict[str, object],
         if k not in safe:
             continue
         s = safe[k]
-        if s == True:
+        if s is True:
             if isinstance(v, dict):
                 # value expected, but got dict instead
                 raise ValueError('Unexpected dict in data: %s' % v)


### PR DESCRIPTION
This PR adds the possibility of uploading minimal test results. This is best described by the corresponding text in `testing.conf`:

> Enables minimal uploads mode. In minimal mode, no information that is
> potentially sensitive is uploaded to the test results server. Specifically,
> only the following are uploaded:
>   - code related identifiers, such as branch names, class names, etc.
>   - times and dates
>   - test related identifiers, such as run id
>   - the maintainer email, if one is provided
>   - boolean values, such as whether the target system has mpirun available,
>     etc.
>   - git identifiers and counts: branch name, last commit hash, how many
>     commits the local code has ahead/behind of the remote, and if there
>     are any local changes
>   - the result status of tests, excluding string error messages coming from
>     tests
>
> Excluded items include, but are not limited to:
>   - stdout/stderr from tests
>   - logs from tests
>   - filesystem paths
>
> The full information is still saved locally and can be accessed and manually
> vetted if required. Setting this to "true" automatically enables saving of
> results to files.

What is included in the upload is defined by a whitelist (specified above). That is, nothing outside the whitelist is included.
