### PR TITLE
Gracefully deal with missing crontabs rather than failing

### DIFF
--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -33,11 +33,11 @@ crontab_list() {
 
 
 cron_check_existing() {
-    crontab_list 2>/dev/null | grep "psij-ci-run" >/dev/null 2>&1
+    crontab_list | grep "psij-ci-run" >/dev/null 2>&1
 }
 
 cron_existing_error() {
-    EXISTING=`crontab_list 2>/dev/null | grep "psij-ci-run"`
+    EXISTING=`crontab_list | grep "psij-ci-run"`
     echo
     echo "================================================================"
     echo "Error: a crontab for PSI/J tests already exists:                "

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -21,13 +21,23 @@ cron_check() {
     echo "$(($S1 || ! $S2))"
 }
 
+crontab_list() {
+    # wraps crontab -l such that an empty string is returned for a missing
+    # crontab rather than an error
+    if crontab -l 2>&1 | grep "no crontab for" >/dev/null 2>&1 ; then
+        echo ""
+    else
+        crontab -l
+    fi
+}
+
 
 cron_check_existing() {
-    crontab -l 2>/dev/null | grep "psij-ci-run" >/dev/null 2>&1
+    crontab_list 2>/dev/null | grep "psij-ci-run" >/dev/null 2>&1
 }
 
 cron_existing_error() {
-    EXISTING=`crontab -l 2>/dev/null | grep "psij-ci-run"`
+    EXISTING=`crontab_list 2>/dev/null | grep "psij-ci-run"`
     echo
     echo "================================================================"
     echo "Error: a crontab for PSI/J tests already exists:                "
@@ -47,7 +57,7 @@ cron_install() {
     echo "The following line will be installed in your crontab:"
     echo "$LINE"
     echo "================================================================"
-    { crontab -l && echo "$LINE"; } | crontab -
+    { crontab_list && echo "$LINE"; } | crontab -
     
     declare -x | egrep -v "^declare -x (BASH_VERSINFO|DISPLAY|EUID|GROUPS|SHELLOPTS|TERM|UID|_)=" >psij-ci-env
 }


### PR DESCRIPTION
This fixes #239.

To test, check out main, remove crontab files with `crontab -r` (don't do this if you have important stuff in your crontab; alternatively, do so under a test login). Then psij-ci-setup with cron should fail to produce a crontab and end with the error 'no crontab for <user>'.

The check out this branch, ensure no crontab again (`crontab -r`) and run psij-ci-setup. It should succeed (i.e., `crontab -l` should list the new job).