### PR TITLE
Doc selectors tab mode

### DIFF
--- a/docs/README-selectors.md
+++ b/docs/README-selectors.md
@@ -10,15 +10,21 @@ This will add a heading before the next code block containing:
 
     "See example for [Local >]",
 
-where `[Local >]` is a drop-down with the options listed above (i.e., Local, Slurm, LSF, PBS, Cobalt).
-Alternatively, one can add the class "selector-mode-tabs" to the `rst-class` directive above to 
-display the options as tabs.
+where `[Local >]` is a drop-down with the options listed above (i.e.,
+Local, Slurm, LSF, PBS, Cobalt). Alternatively, one can add the class
+"selector-mode-tabs" to the `rst-class` directive above to  display the
+options as tabs.
 
-In the code block, you can use the string `"<&executor-type>"` to substitute the value selected in the selector. For example:
+In the code block, you can use the string `"<&executor-type>"` to
+substitute the value selected in the selector. For example:
 
     x = f("<&executor-type>")
 
-When rendered, the `<&executor-type>` string will be replaced by the lower case version of the selected value in the immediately preceeding selector. The string `"<&executor-type>"` must be a standalone token as far as the syntax highlighter is concerned. That is, it probably won't work if it's in a comment.
+When rendered, the `<&executor-type>` string will be replaced by the
+lower case version of the selected value in the immediately preceeding
+selector. The string `"<&executor-type>"` must be a standalone token as
+far as the syntax highlighter is concerned. That is, it probably won't
+work if it's in a comment.
 
 To add alternative code blocks, use:
 
@@ -34,9 +40,15 @@ To add alternative code blocks, use:
     # code for Slurm executor
 ```
 
-Alternate code blocks as well as value substitutions bind to the closest preceeding selector. However, selectors are synchronized, in that selecting "Local" in one selector, will also select "Local" in all other selectors of the same type (i.e. "executor-type-*") that have "Local" as a listed value. If a selector does not have that value, the values and blocks bound to it are left untouched.
+Alternate code blocks as well as value substitutions bind to the closest
+preceeding selector. However, selectors are synchronized, in that
+selecting "Local" in one selector, will also select "Local" in all other
+selectors of the same type (i.e. "executor-type-*") that have "Local" as
+a listed value. If a selector does not have that value, the values and
+blocks bound to it are left untouched.
 
-By default, only "executor-type-" selectors are available. More can be added using:
+By default, only "executor-type-" selectors are available. More can be
+added using:
 
 ```Sphinx
 .. raw:: html
@@ -44,7 +56,9 @@ By default, only "executor-type-" selectors are available. More can be added usi
     <script>addSelectorType("site-name", "localhost");</script>,
 ```
 
-where "site-name" is like "executor-type" above, and "localhost" is the value used by default. In other words, using "site-name" selectors is now done as follows:
+where "site-name" is like "executor-type" above, and "localhost" is the
+value used by default. In other words, using "site-name" selectors is now
+done as follows:
 
 ```
 .. rst-class:: site-name-selector

--- a/docs/README-selectors.md
+++ b/docs/README-selectors.md
@@ -10,7 +10,9 @@ This will add a heading before the next code block containing:
 
     "See example for [Local >]",
 
-where `[Local >]` is a drop-down with the options listed above (i.e., Local, Slurm, LSF, PBS, Cobalt)
+where `[Local >]` is a drop-down with the options listed above (i.e., Local, Slurm, LSF, PBS, Cobalt).
+Alternatively, one can add the class "selector-mode-tabs" to the `rst-class` directive above to 
+display the options as tabs.
 
 In the code block, you can use the string `"<&executor-type>"` to substitute the value selected in the selector. For example:
 

--- a/docs/_static/extras.js
+++ b/docs/_static/extras.js
@@ -69,7 +69,7 @@ function detectAll(selectorType) {
 }
 
 function initializeSelectors(selectorType, defaultValue) {
-    var context = {lastSelector: null, lastValues: null};
+    var context = {lastValues: null, tabsIndex: 0};
     $("." + selectorType + "-item").each(function() {
         if ($(this).is("p")) {
             // selector
@@ -92,6 +92,7 @@ function initializeSelectors(selectorType, defaultValue) {
 
 function globalSelectSelectorValue(selectorType, value) {
     $("select." + selectorType + "-selector option[value=\"" + value + "\"]").prop("selected", true);
+    $("input." + selectorType + "-selector[value=\"" + value + "\"]").prop("checked", true);
     $("." + selectorType + "-value").each(function() {
         if ($(this).parent().data("allowed-values").includes(value)) {
             $(this).fadeTo(300, 0.01, function() {
@@ -116,12 +117,21 @@ function globalSelectSelectorValue(selectorType, value) {
 function initializeSelector(context, $el, selectorType, selectedValue) {
     var text = $el.text();
     var values = text.split(/\s*\/\/\s*/); // split on "//" possible with whitespace around
-    var select = $("<select>").addClass(selectorType + "-selector").addClass("psij-selector");
-    $el.html($("<label>").text("See example for "));
     
     context.lastValues = values;
-    context.lastSelector = select;
     
+    if ($el.hasClass("selector-mode-tabs")) {
+        initializeSelectorTabs(context, $el, selectorType, values, selectedValue);
+    }
+    else {
+        initializeSelectorDropdown(context, $el, selectorType, values, selectedValue);
+    }
+}
+
+function initializeSelectorDropdown(context, $el, selectorType, values, selectedValue) {
+    var select = $("<select>").addClass(selectorType + "-selector").addClass("psij-selector");
+    $el.html($("<label>").text("See example for "));
+
     values.forEach(function(value) {
         var option = $("<option>").attr("value", value).text(value);
         if (value == selectedValue) {
@@ -133,8 +143,40 @@ function initializeSelector(context, $el, selectorType, selectedValue) {
         globalSelectSelectorValue(selectorType, $(this).val());
     });
     $el.addClass("initialized");
+    $el.addClass("selector-container-dropdown");
     select.appendTo($el);
 }
+
+function initializeSelectorTabs(context, $el, selectorType, values, selectedValue) {
+    var i = 0;
+    $el.html(""); // remove unparsed labels
+    values.forEach(function(value) {
+        var input = $("<input></input>")
+				.addClass("selector-radio").addClass(selectorType + "-selector")
+				.attr("type", "radio")
+				.attr("name", "_" + selectorType + "-" + context.tabsIndex)
+				.attr("id", "_" + selectorType + "-" + context.tabsIndex + "-" + i)
+				.attr("value", value);
+		if (value == selectedValue) {
+		    input.prop("checked", true);
+		}
+        input.appendTo($el);
+        input.change(function() {
+            globalSelectSelectorValue(selectorType, $(this).val());
+        });
+        var label = $("<label></label>")
+				.addClass("selector-label")
+				.attr("for", "_" + selectorType + "-" + context.tabsIndex + "-" + i)
+				.html(value);
+		$el.addClass("initialized");
+	    label.appendTo($el);
+	    i++;
+    });
+    context.tabsIndex++;
+    $el.addClass("selector-container-tabs");
+}
+
+
 
 function initializeSimpleValue(context, $el, selectorType, selectedValue) {
     $el.html($("<span>").addClass(selectorType + "-value").text('"' + selectedValue.toLowerCase() + '"'));

--- a/docs/_static/extras.js
+++ b/docs/_static/extras.js
@@ -126,6 +126,8 @@ function initializeSelector(context, $el, selectorType, selectedValue) {
     else {
         initializeSelectorDropdown(context, $el, selectorType, values, selectedValue);
     }
+     $el.addClass("initialized")
+        .addClass("selector-container");
 }
 
 function initializeSelectorDropdown(context, $el, selectorType, values, selectedValue) {
@@ -142,7 +144,6 @@ function initializeSelectorDropdown(context, $el, selectorType, values, selected
     select.change(function() {
         globalSelectSelectorValue(selectorType, $(this).val());
     });
-    $el.addClass("initialized");
     $el.addClass("selector-container-dropdown");
     select.appendTo($el);
 }

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -33,7 +33,7 @@ PSI/J supports a number of common batch schedulers, providing a common Python in
 Choose from the tabs below for a simple example showing how to submit a job for that scheduler.  
 
 
-.. rst-class:: executor-type-selector
+.. rst-class:: executor-type-selector selector-mode-tabs
 
 Local // Slurm // LSF // PBS // Cobalt
 

--- a/web/docs/_static/cloud.css
+++ b/web/docs/_static/cloud.css
@@ -1474,17 +1474,24 @@ div.body p.executor-type-selector {
     margin: 0 2pt 0 2pt;
     margin-top: 1em;
     position: relative;
-    top: 1.5em;
-    background-color: #e8e8e8;
-    padding-bottom: 0.5em;
     padding-left: 8pt;
     padding-top: 6pt;
+    top: 1.5em;
     z-index: 1;
-    border-bottom: thin solid #c0c0c0;
     border-radius: 4pt;
 }
 
-div.highlight-python {
+div.body p.selector-container-dropdown {
+    background-color: #e8e8e8;
+    padding-bottom: 0.5em;
+    border-bottom: thin solid #c0c0c0;
+}
+
+div.body p.selector-container-tabs {
+    padding-bottom: 0;
+}
+
+div.highlight pre {
     z-index: 2;
 }
 
@@ -1513,4 +1520,39 @@ select.psij-selector:focus {
     outline: none;
     border-color: var(--color-fg-lines);
     box-shadow: 0 0 1.5pt var(--color-fg-lines);
+}
+
+.selector-radio {
+	width: 0;
+    height: 0;
+}
+
+.selector-label {
+	cursor: pointer;
+
+	font-size: 94%;
+
+	z-index: 1;
+	display: inline-block;
+	position: relative;
+	min-width: 80pt;
+
+	padding: 3pt;
+	padding-left: 8pt;
+	top: 2pt;
+	height: 22pt;
+
+	background-color: #d8d8d8;
+	border: thin solid #d8d8d8;
+	border-radius: 3pt 3pt 0 0;
+	margin-right: 1pt;
+}
+
+.selector-radio:checked + .selector-label {
+	z-index: 3;
+	top: 0pt;
+	height: 24pt;
+	background-color: #e8e8e8;
+	border: thin solid #e8e8e8;
+	border-bottom: thin solid #e8e8e8;
 }

--- a/web/docs/_static/cloud.css
+++ b/web/docs/_static/cloud.css
@@ -1470,7 +1470,7 @@ div.highlight pre {
 	border-color: transparent;
 }
 
-div.body p.executor-type-selector {
+div.body p.selector-container {
     margin: 0 2pt 0 2pt;
     margin-top: 1em;
     position: relative;


### PR DESCRIPTION
You can now add an extra class to *-selector to make it show up as tabs.

![screenshot](https://user-images.githubusercontent.com/7749227/189469845-efd24ff8-6094-44e0-ab40-e63e1920b8e6.png)
