### PR TITLE
web: fix minimum Python version

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -159,7 +159,7 @@
                             <div style="margin-top: 1em">
                                 The psi-j-python library has the following requirements:
                                 <ul>
-                                    <li>Python 3.6 or later
+                                    <li>Python 3.7 or later
                                     <li>Ubuntu 16.04 or later (or an equivalent Linux distribution)
                                     <li>OS X 10.10 or later
                                 </ul>


### PR DESCRIPTION
The minimum version was upgraded to 3.7 in PR #126 .

This is the last reference to 3.6 in the code base.