### PR TITLE
Fix firefox iframe scroll

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ html_sidebars = {'**': ['globaltoc.html', 'relations.html', 'sourcelink.html', '
 
 # These are needed for the dhtml trickery
 html_static_path = ["_static"]
-html_js_files = ["https://code.jquery.com/jquery-3.5.1.min.js", "extras.js"]
+html_js_files = ["extras.js"]
 
 # Setup Sphinx extensions (and associated variables)
 extensions = [

--- a/web/lib.js
+++ b/web/lib.js
@@ -11,20 +11,29 @@ docsHashChange = function(path, hash) {
         hash = hash.substr(1);
     }
     path = path.substr("/docs/".length);
-    window.scrollTo(window.scrollX, window.scrollY - 56);
+
+    scrollToHash(hash);
     window.location.hash = buildPath({tab: "docs", doc: path, dochash: hash});
 }
 
-docsLoaded = function(path, hash) {
-    docsHashChange(path, hash);
-    resizeDocsFrame();
+function scrollToHash(hash) {
     if (hash) {
-        var anchor = window.docs.document.getElementById(hash.substr(1));
+        if (hash.length > 0 && hash.charAt(0) == "#") {
+            hash = hash.substr(1);
+        }
+        var anchor = window.docs.document.getElementById(hash);
         if (anchor) {
             anchor.scrollIntoView();
             window.scrollTo(window.scrollX, window.scrollY - 56);
         }
     }
+
+}
+
+docsLoaded = function(path, hash) {
+    docsHashChange(path, hash);
+    resizeDocsFrame();
+    scrollToHash(hash);
 
     var html = document.getElementsByTagName("html")[0];
     var body = document.getElementsByTagName("body")[0];


### PR DESCRIPTION
Firefox does not properly scroll to anchors in an iframe if the iframe is
very large. There appear to be similar issues in Firefox which can be fixed
by explicitly calling `scrollIntoView()` on the target element. This
solution appears to work here, too.

The problem manifests itself if you go to, e.g., the API ref for Cobalt and
try to either click on permalinks for the various methods or attempt to
navigate to the "See <base class method>" links.
