### PR TITLE
A merge of a dependabot update was wrongfully done.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 psutil >=5.9, <=7.2.2
-pystache>=0.6.8
+pystache>=0.6.0
 typeguard>=4.0.0
 packaging >= 24.0, <= 26.0


### PR DESCRIPTION
Dependabot claimed to have updated the upper bound on a number of dependencies when only the lower bound was updated. However, we do not want to needlessly narrow the version range.