### PR TITLE
Updated dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    versioning-strategy: auto
+    versioning-strategy: widen
     allow:
       - dependency-name: "filelock"
       - dependency-name: "psutil"
       - dependency-name: "pystache"
       - dependency-name: "typeguard"
       - dependency-name: "packaging"
-      
+      - dependency-name: "aiofile"


### PR DESCRIPTION
Ensure that the upgrade strategy is "widen". We want to keep the lower bounds unchanged since we want the largest functional set of versions to be included.